### PR TITLE
Add "active visitors" system to events.

### DIFF
--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -1,12 +1,19 @@
 from pylons.i18n import N_
 
 from r2.config.routing import not_in_sr
+from r2.lib.configparse import ConfigValue
 from r2.lib.js import Module, LocalizedModule, TemplateFileSource
 from r2.lib.plugin import Plugin
 
 
 class LiveUpdate(Plugin):
     needs_static_build = True
+
+    config = {
+        ConfigValue.str: [
+            "liveupdate_pixel_domain",
+        ],
+    }
 
     js = {
         "liveupdate": LocalizedModule("liveupdate.js",

--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -28,6 +28,10 @@ class LiveUpdate(Plugin):
         mc("/live/:event", controller="liveupdate", action="listing",
            conditions={"function": not_in_sr})
 
+        mc("/live/:event/pixel",
+           controller="liveupdatepixel", action="pixel",
+           conditions={"function": not_in_sr})
+
         mc("/live/:event/:action", controller="liveupdate",
            conditions={"function": not_in_sr})
 
@@ -35,7 +39,10 @@ class LiveUpdate(Plugin):
            conditions={"function": not_in_sr})
 
     def load_controllers(self):
-        from reddit_liveupdate.controllers import LiveUpdateController
+        from reddit_liveupdate.controllers import (
+            LiveUpdateController,
+            LiveUpdatePixelController,
+        )
 
         from r2.config.templates import api
         from reddit_liveupdate import pages

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -14,7 +14,7 @@ from r2.lib.memoize import memoize
 from r2.lib.wrapped import Templated, Wrapped
 from r2.models import Account, Subreddit, Link, NotFound, Listing
 from r2.lib.strings import strings
-from r2.lib.utils import tup
+from r2.lib.utils import tup, fuzz_activity
 from r2.lib.jsontemplates import (
     JsonTemplate,
     ObjectTemplate,
@@ -22,6 +22,7 @@ from r2.lib.jsontemplates import (
 )
 
 from reddit_liveupdate.utils import pretty_time, pairwise
+from reddit_liveupdate.models import ActiveVisitorsByLiveUpdateEvent
 
 
 class LiveUpdateTitle(Templated):
@@ -80,6 +81,7 @@ class LiveUpdateEvent(Templated):
         self.event = event
         self.listing = listing
         self.discussions = LiveUpdateOtherDiscussions()
+        self.visitor_count = self._get_active_visitors()
 
         editor_accounts = Account._byID(event.editor_ids,
                                         data=True, return_dict=False)
@@ -87,6 +89,18 @@ class LiveUpdateEvent(Templated):
                               key=lambda e: e.name)
 
         Templated.__init__(self)
+
+    def _get_active_visitors(self):
+        count = ActiveVisitorsByLiveUpdateEvent.get_count(self.event)
+
+        if count < 100 and not c.user_is_admin:
+            cache_key = "liveupdate_visitors-" + str(self.event._id)
+            fuzzed_count = g.cache.get(cache_key)
+            if not fuzzed_count:
+                fuzzed_count = fuzz_activity(count)
+                g.cache.set(cache_key, fuzzed_count, time=5 * 60)
+            return "~%d" % fuzzed_count
+        return count
 
 
 class LiveUpdateEventConfiguration(Templated):

--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -37,11 +37,15 @@
 
         p {
             display: inline-block;
+            margin-right: 1em;
+
+            &#visitor-count {
+                margin-right: 2em;
+            }
         }
 
         ul {
             display: inline-block;
-            margin-left: .5em;
         }
 
         li {

--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -46,7 +46,19 @@
 
         li {
             display: inline-block;
-            margin-right: 1em;
+            margin: 0 .5em 0 0;
+
+            a {
+                margin-right: .1em;
+            }
+
+            &:after {
+                content: " + ";
+            }
+
+            &:last-child:after {
+                content: "";
+            }
         }
     }
 }

--- a/reddit_liveupdate/templates/liveupdateevent.html
+++ b/reddit_liveupdate/templates/liveupdateevent.html
@@ -14,6 +14,8 @@
     <p class="state live">${_("live")}</p>
   % endif
 
+  <p id="visitor-count">${_("viewers:")}&nbsp;<span>${thing.visitor_count}</span></p>
+
   <p>${_("reported by:")}</p>
 
   <ul>
@@ -53,3 +55,5 @@
 
 ${thing.listing}
 </div>
+
+<img src="/live/${c.liveupdate_event._id}/pixel.png" height="1" width="1" alt="">

--- a/reddit_liveupdate/templates/liveupdateevent.html
+++ b/reddit_liveupdate/templates/liveupdateevent.html
@@ -56,4 +56,4 @@
 ${thing.listing}
 </div>
 
-<img src="/live/${c.liveupdate_event._id}/pixel.png" height="1" width="1" alt="">
+<img src="//${g.liveupdate_pixel_domain}/live/${c.liveupdate_event._id}/pixel.png" height="1" width="1" alt="">


### PR DESCRIPTION
This aims to help two goals:
- Fixes #13 by providing a counter which hopefully makes the
  liveupdate page feel less lonely since you'll see how many others
  are also viewing it.
- For the future: Provide a good activity metric which can be used to
  sort events when building a listing of active events.

When automatic polling is in place, the "pixel" should be fetched
periodically so that the number indicates people who're just watching
the page, not just refreshing, as well.
