### PR TITLE
Allow framing of the embed and fire activity pixel periodically.

### DIFF
--- a/reddit_liveupdate/activity.py
+++ b/reddit_liveupdate/activity.py
@@ -22,4 +22,6 @@ def broadcast_update():
         websockets.send_broadcast(
             "/live/" + event_id, type="activity", payload=payload)
 
+    # ensure that all the amqp messages we've put on the worker's queue are
+    # sent before we allow this script to exit.
     amqp.worker.join()

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -150,9 +150,11 @@ class LiveUpdateController(RedditController):
                 websocket_url=websocket_url,
             ).render()
         else:
-            # embeds should always look logged out for simplicity
+            # embeds are always logged out and therefore safe for frames.
             c.liveupdate_can_manage = False
             c.liveupdate_can_edit = False
+            c.allow_framing = True
+
             return pages.LiveUpdateEmbed(
                 content=content,
                 websocket_url=websocket_url,

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -37,6 +37,7 @@ class LiveUpdatePage(Reddit):
     def __init__(self, content, websocket_url=None):
         extra_js_config = {
             "liveupdate_event": c.liveupdate_event._id,
+            "liveupdate_pixel_domain": g.liveupdate_pixel_domain,
         }
 
         if websocket_url:

--- a/reddit_liveupdate/public/static/js/liveupdate.js
+++ b/reddit_liveupdate/public/static/js/liveupdate.js
@@ -1,4 +1,6 @@
 r.liveupdate = {
+    _pixelInterval: 10 * 60 * 1000,
+
     init: function () {
         this.$listing = $('.liveupdate-listing')
         this.$table = this.$listing.find('table tbody')
@@ -22,6 +24,8 @@ r.liveupdate = {
                 'message:update': this._onNewUpdate
             }, this)
         }
+
+        this._fetchPixel()
     },
 
     _onWebSocketConnecting: function () {
@@ -129,6 +133,17 @@ r.liveupdate = {
             .always($.proxy(function () {
                 this.$listing.removeClass('loading')
             }, this))
+    },
+
+    _fetchPixel: function () {
+        var pixel = new Image()
+        pixel.src = '//' + r.config.liveupdate_pixel_domain +
+                    '/live/' + r.config.liveupdate_event + '/pixel.png' +
+                    '?rand=' + Math.random()
+
+        var delay = Math.floor(this._pixelInterval -
+                               this._pixelInterval * Math.random() / 2)
+        setTimeout($.proxy(this, '_fetchPixel'), delay)
     }
 }
 

--- a/reddit_liveupdate/templates/liveupdateevent.html
+++ b/reddit_liveupdate/templates/liveupdateevent.html
@@ -57,5 +57,3 @@
 
 ${thing.listing}
 </div>
-
-<img src="//${g.liveupdate_pixel_domain}/live/${c.liveupdate_event._id}/pixel.png" height="1" width="1" alt="">


### PR DESCRIPTION
Since the websocketpocalypse, you no longer need to refresh to get new updates. This means the static pixel is no longer sufficient to keep the activity tracker up to date.  The client will now periodically fetch pixels to keep the activity count accurate.

A couple of tiny other fixes include allowing framing for the embed (oops) and adding a comment about the worker joining thingy.

:eyeglasses: @chromakode 
