### PR TITLE
Convert a None UA to empty string if necessary.

### DIFF
--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -79,7 +79,7 @@ class LiveUpdatePixelController(BaseController):
             abort(404)
 
         event_id = event[:50]  # some very simple poor-man's validation
-        user_agent = getattr(request, 'user_agent', '')
+        user_agent = request.user_agent or ''
         user_id = hashlib.sha1(request.ip + user_agent).hexdigest()
         ActiveVisitorsByLiveUpdateEvent.touch(event_id, user_id)
 


### PR DESCRIPTION
I forgot that `request.user_agent` will always exist, but it'll sometimes be `None`.

:eyeglasses: @spladug
