### PR TITLE
Fix Tinycon cross-domain issues and initial setup.

### DIFF
--- a/reddit_liveupdate/public/static/js/liveupdate.js
+++ b/reddit_liveupdate/public/static/js/liveupdate.js
@@ -1,5 +1,6 @@
 r.liveupdate = {
     _pixelInterval: 10 * 60 * 1000,
+    _favicon: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAA/1BMVEUpLzY+PDpGSk5HR0dKTlNSW2VTXGVVXmdWWl5bYWZdZGtfanVfbHpgXVtianNjbXhkZWdkam1lcX1nc4BpdYJqa2xscHZucHJueYRvfoxwfIhxcG93e4B3h5h4iJh5ipt7gIB8ipl+fn6BgYGImKOJh4aKjY2Mna6NobSOn7CQo7iar8Wfnp2juM6lo6Gmuc6mu8moqaqsw9etwcmurq6vrauxyN2xyN+0s7K+u7m/1u7C2vPF3fbI4PrJ4fvJ4/7Ly8vPzMnP6P7S0tLT0c/W8P/Z19Xd9/7d+P7e3Nrw8PDz9vT69/T+EA/+MjD+pqT+srD+w8H+zsz+/v7///9fla50AAAAuElEQVR42l2P2RaBUBhGT0WZ54jIPM8h0zE7SBL97/8uYoXFvtwXe30fIn8ggn94i8XMGSkFQvmPwFXvwOe/OGyx3OJYF+OUq26LcS2LMs05Xj0bPY+QDFc6k1bOnRQ8PYLiKlXW4IlWptQ4QWlxCIZ+h7tuwFBME9RgAG5XE8zrDYBpWNEEfElY0RO7Aejvzrs+wIa1xFGmp7AuFoprmNLya4fC8aP9YT/iOeX9pS1Fg1GpbZ/74wFo2jf64C4agwAAAABJRU5ErkJggg==',
 
     init: function () {
         this.$listing = $('.liveupdate-listing')
@@ -30,6 +31,8 @@ r.liveupdate = {
         Tinycon.setOptions({
             'background': '#ff4500'
         })
+        Tinycon.setImage(this._favicon)
+        Tinycon.setBubble()  // ensures that reset() is safe
 
         $(document).on({
             'show': $.proxy(this, '_onPageVisible'),


### PR DESCRIPTION
Because the image is coming from www.redditstatic.com in production,
it's breaking tinycon's ability to render a new favicon.  Instead, we'll
embed the icon directly as a data uri.  This also fixes an issue where
the main icon provides a 32x32 version as well which Chrome prefers and
makes the favicon look different after adding a bubble.

Adding the initial empty setBubble() call ensures that tinycon is aware
of the original image before onPageVisible calls reset().

:eyeglasses: @chromakode 
