### PR TITLE
Use live timestamps for update dates

### DIFF
--- a/reddit_liveupdate/public/static/js/liveupdate.js
+++ b/reddit_liveupdate/public/static/js/liveupdate.js
@@ -80,7 +80,7 @@ r.liveupdate = {
 
     _onRefresh: function () {
         // delay a random amount to reduce thundering herd
-        var delay = Math.random() * 60 * 1000
+        var delay = Math.random() * 300 * 1000
         setTimeout(function () { location.reload() }, delay)
     },
 

--- a/reddit_liveupdate/public/static/js/timetext.js
+++ b/reddit_liveupdate/public/static/js/timetext.js
@@ -36,8 +36,14 @@ r.timetext = {
             now = Date.now()
 
         var $el = $(el)
-        var isoTimestamp = $el.attr('datetime')
-        var timestamp = Date.parse(isoTimestamp)
+        var timestamp = $el.data('timestamp')
+
+        if (!timestamp) {
+            var isoTimestamp = $el.attr('datetime')
+            timestamp = Date.parse(isoTimestamp)
+            $el.data('timestamp', timestamp)
+        }
+
         var age = (now - timestamp) / 1000
         var chunks = r.timetext._chunks
         var text = r._('less than a minute ago')

--- a/reddit_liveupdate/templates/liveupdate.html
+++ b/reddit_liveupdate/templates/liveupdate.html
@@ -10,7 +10,7 @@
 
 <tr data-fullname="${thing._fullname}" class="thing id-${thing._fullname} ${"stricken" if thing.stricken else ""}">
   <th scope="row">
-    <time title="${format_datetime(thing._date, format='long', tzinfo=c.liveupdate_event.timezone, locale=c.locale)}" datetime="${html_datetime(thing._date)}">${thing.date_str}</time>
+    <time title="${format_datetime(thing._date, format='long', tzinfo=c.liveupdate_event.timezone, locale=c.locale)}" datetime="${html_datetime(thing._date)}" class="live">${thing.date_str}</time>
   </th>
 
   <td class="md">


### PR DESCRIPTION
I had this originally, but my local test data at the time had lots of updates posted close together. This made the UI look awful with a whole string of "x minutes ago" posts.   However, in reality, it looks pretty good and takes care of many of the issues people have with the timestamps.

![timetext in action](https://f.cloud.github.com/assets/338853/2226948/559dac32-9ab3-11e3-84af-24c1bacc6a2d.png)

:eyeglasses: @chromakode 
