### PR TITLE
Improvements to how we track activity on the backend.

### DIFF
--- a/reddit_liveupdate/activity.py
+++ b/reddit_liveupdate/activity.py
@@ -1,18 +1,29 @@
-from r2.lib import amqp, websockets
+from r2.lib import amqp, websockets, utils
 
-from reddit_liveupdate.models import ActiveVisitorsByLiveUpdateEvent
+from reddit_liveupdate.models import (
+    ActiveVisitorsByLiveUpdateEvent,
+    LiveUpdateEvent,
+)
 
 
-def broadcast_update():
+ACTIVITY_FUZZING_THRESHOLD = 100
+
+
+def update_activity():
     event_ids = ActiveVisitorsByLiveUpdateEvent._cf.get_range(
         column_count=1, filter_empty=False)
 
     for event_id, is_active in event_ids:
+        count = 0
         if is_active:
-            count, is_fuzzed = ActiveVisitorsByLiveUpdateEvent.get_count(
-                event_id, cached=False)
-        else:
-            count, is_fuzzed = 0, False
+            count = ActiveVisitorsByLiveUpdateEvent.get_count(event_id)
+
+        LiveUpdateEvent.update_activity(event_id, count)
+
+        is_fuzzed = False
+        if count < ACTIVITY_FUZZING_THRESHOLD:
+            count = utils.fuzz_activity(count)
+            is_fuzzed = True
 
         payload = {
             "count": count,

--- a/reddit_liveupdate/activity.py
+++ b/reddit_liveupdate/activity.py
@@ -25,13 +25,14 @@ def update_activity():
             count = utils.fuzz_activity(count)
             is_fuzzed = True
 
-        payload = {
-            "count": count,
-            "fuzzed": is_fuzzed,
-        }
-
         websockets.send_broadcast(
-            "/live/" + event_id, type="activity", payload=payload)
+            "/live/" + event_id,
+            type="activity",
+            payload={
+                "count": count,
+                "fuzzed": is_fuzzed,
+            },
+        )
 
     # ensure that all the amqp messages we've put on the worker's queue are
     # sent before we allow this script to exit.

--- a/reddit_liveupdate/activity.py
+++ b/reddit_liveupdate/activity.py
@@ -3,6 +3,7 @@ from r2.lib import amqp, websockets, utils
 from reddit_liveupdate.models import (
     ActiveVisitorsByLiveUpdateEvent,
     LiveUpdateEvent,
+    LiveUpdateActivityHistoryByEvent,
 )
 
 
@@ -19,6 +20,7 @@ def update_activity():
             count = ActiveVisitorsByLiveUpdateEvent.get_count(event_id)
 
         LiveUpdateEvent.update_activity(event_id, count)
+        LiveUpdateActivityHistoryByEvent.record_activity(event_id, count)
 
         is_fuzzed = False
         if count < ACTIVITY_FUZZING_THRESHOLD:

--- a/reddit_liveupdate/models.py
+++ b/reddit_liveupdate/models.py
@@ -174,3 +174,19 @@ class ActiveVisitorsByLiveUpdateEvent(tdb_cassandra.View):
     @classmethod
     def get_count(cls, event_id):
         return cls._cf.get_count(event_id)
+
+
+class LiveUpdateActivityHistoryByEvent(tdb_cassandra.View):
+    _use_db = True
+    _connection_pool = "main"
+    _compare_with = "TimeUUIDType"
+    _value_type = "bytes"  # use pycassa, not tdb_c*, to serialize
+    _read_consistency_level = tdb_cassandra.CL.QUORUM
+    _write_consistency_level = tdb_cassandra.CL.QUORUM
+    _extra_schema_creation_args = {
+        "default_validation_class": "IntegerType",
+    }
+
+    @classmethod
+    def record_activity(cls, event_id, activity_count):
+        cls._set_values(event_id, {uuid.uuid1(): activity_count})

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -15,15 +15,15 @@ from r2.lib.memoize import memoize
 from r2.lib.wrapped import Templated, Wrapped
 from r2.models import Account, Subreddit, Link, NotFound, Listing, UserListing
 from r2.lib.strings import strings
-from r2.lib.utils import tup
+from r2.lib.utils import tup, fuzz_activity
 from r2.lib.jsontemplates import (
     JsonTemplate,
     ObjectTemplate,
     ThingJsonTemplate,
 )
 
+from reddit_liveupdate.activity import ACTIVITY_FUZZING_THRESHOLD
 from reddit_liveupdate.utils import pretty_time, pairwise
-from reddit_liveupdate.models import ActiveVisitorsByLiveUpdateEvent
 
 
 class LiveUpdateTitle(Templated):
@@ -107,11 +107,10 @@ class LiveUpdateEvent(Templated):
         Templated.__init__(self)
 
     def _get_active_visitors(self):
-        count, is_fuzzed = ActiveVisitorsByLiveUpdateEvent.get_count(
-            self.event._id, fuzz=not c.user_is_admin)
+        count = self.event.active_visitors
 
-        if is_fuzzed:
-            return "~%d" % count
+        if count < ACTIVITY_FUZZING_THRESHOLD and not c.user_is_admin:
+            return "~%d" % fuzz_activity(count)
         return count
 
 

--- a/upstart/reddit-job-liveupdate_activity.conf
+++ b/upstart/reddit-job-liveupdate_activity.conf
@@ -8,5 +8,5 @@ nice 10
 
 script
     . /etc/default/reddit
-    wrap-job paster run $REDDIT_INI -c 'from reddit_liveupdate import activity; activity.broadcast_update()'
+    wrap-job paster run $REDDIT_INI -c 'from reddit_liveupdate import activity; activity.update_activity()'
 end script


### PR DESCRIPTION
The current activity tracking system is based heavily on the similar subreddit activity counts.  However, since we now have a cron job that counts activity and broadcasts it on sockets, we can take advantage of that to remove the memoize and fuzz-caching stuff and drastically simplify the in-request behaviour. The cron job will, in addition to its previous duties as socket broadcaster, update an attribute of the event itself which is used in-request.  If Cassandra slows down on the `get_count`s for some reason, it will no longer have any effect on live requests.

This also made it super easy to add a time-series CF for historical activity numbers. 

:eyeglasses: @alienth
