### PR TITLE
Fixes for timetext plural string translations

### DIFF
--- a/reddit_liveupdate/public/static/js/timetext.js
+++ b/reddit_liveupdate/public/static/js/timetext.js
@@ -6,16 +6,13 @@ if (!Date.now) {
 }
 
 r.timetext = {
-    _chunks: (function () {
-        function P_(x, y) { return [x, y] }
-        return [
-            [60 * 60 * 24 * 365, P_('a year ago', '%(num)s years ago')],
-            [60 * 60 * 24 * 30, P_('a month ago', '%(num)s months ago')],
-            [60 * 60 * 24, P_('a day ago', '%(num)s days ago')],
-            [60 * 60, P_('an hour ago', '%(num)s hours ago')],
-            [60, P_('a minute ago', '%(num)s minutes ago')]
-        ]
-    })(),
+    _chunks: [
+        [60 * 60 * 24 * 365, r.NP_('a year ago', '%(num)s years ago')],
+        [60 * 60 * 24 * 30, r.NP_('a month ago', '%(num)s months ago')],
+        [60 * 60 * 24, r.NP_('a day ago', '%(num)s days ago')],
+        [60 * 60, r.NP_('an hour ago', '%(num)s hours ago')],
+        [60, r.NP_('a minute ago', '%(num)s minutes ago')]
+    ],
 
     init: function () {
         this.refresh()

--- a/reddit_liveupdate/public/static/js/timetext.js
+++ b/reddit_liveupdate/public/static/js/timetext.js
@@ -57,4 +57,6 @@ r.timetext = {
     }
 }
 
-r.timetext.init()
+$(function () {
+    r.timetext.init()
+})


### PR DESCRIPTION
Apparently I screwed this up pretty badly; timetext's plurals were not properly being extracted during the compilation phase (though they were for `make i18n` so our lovely translators have already translated these strings in many languages).  Additionally, because of `r.timetext.init()` running before the `r.i18n.addMessages` call in the built module, once that other issue was fixed the times would show up in English until the first refresh after page load.

:eyeglasses: @chromakode @umbrae
