### PR TITLE
Granular Reporter Permissions

### DIFF
--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -2,8 +2,14 @@ from pylons.i18n import N_
 
 from r2.config.routing import not_in_sr
 from r2.lib.configparse import ConfigValue
-from r2.lib.js import Module, LocalizedModule, TemplateFileSource
+from r2.lib.js import (
+    LocalizedModule,
+    TemplateFileSource,
+    PermissionsDataSource,
+)
 from r2.lib.plugin import Plugin
+
+from reddit_liveupdate.permissions import ReporterPermissionSet
 
 
 class LiveUpdate(Plugin):
@@ -24,9 +30,12 @@ class LiveUpdate(Plugin):
             "timetext.js",
             "liveupdate.js",
         ),
-        "liveupdate-reporter": Module("liveupdate-reporter.js",
+        "liveupdate-reporter": LocalizedModule("liveupdate-reporter.js",
             "liveupdate-reporter.js",
             TemplateFileSource("liveupdate/edit-buttons.html"),
+            PermissionsDataSource({
+                "liveupdate_reporter": ReporterPermissionSet,
+            }),
         ),
     }
 

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -365,7 +365,6 @@ class LiveUpdateController(RedditController):
         t.attr('rows', 3).html("").val("")
 
     @validatedForm(
-        VLiveUpdateReporterWithPermission("edit"),
         VModhash(),
         update=VLiveUpdate("id"),
     )
@@ -373,19 +372,26 @@ class LiveUpdateController(RedditController):
         if form.has_errors("id", errors.NO_THING_ID):
             return
 
+        if not (c.liveupdate_permissions.allow("edit") or
+                (c.user_is_loggedin and update.author_id == c.user._id)):
+            abort(403)
+
         update.deleted = True
         LiveUpdateStream.add_update(c.liveupdate_event, update)
 
         send_websocket_broadcast(type="delete", payload=update._fullname)
 
     @validatedForm(
-        VLiveUpdateReporterWithPermission("edit"),
         VModhash(),
         update=VLiveUpdate("id"),
     )
     def POST_strike_update(self, form, jquery, update):
         if form.has_errors("id", errors.NO_THING_ID):
             return
+
+        if not (c.liveupdate_permissions.allow("edit") or
+                (c.user_is_loggedin and update.author_id == c.user._id)):
+            abort(403)
 
         update.stricken = True
         LiveUpdateStream.add_update(c.liveupdate_event, update)

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -33,10 +33,11 @@ from reddit_liveupdate.models import (
     LiveUpdateStream,
     ActiveVisitorsByLiveUpdateEvent,
 )
+from reddit_liveupdate.permissions import ReporterPermissionSet
 from reddit_liveupdate.validators import (
     VLiveUpdate,
-    VLiveUpdateEventReporter,
-    VLiveUpdateEventManager,
+    VLiveUpdateReporterWithPermission,
+    VLiveUpdatePermissions,
     VLiveUpdateID,
     VTimeZone,
 )
@@ -58,6 +59,53 @@ class LiveUpdateBuilder(QueryBuilder):
 
     def keep_item(self, item):
         return not item.deleted
+
+
+class LiveUpdateReporter(object):
+    def __init__(self, account, permissions):
+        self.account = account
+        self.permissions = permissions
+
+    @property
+    def _id(self):
+        return self.account._id
+
+
+class LiveUpdateReporterBuilder(SimpleBuilder):
+    def __init__(self, event, editable):
+        self.event = event
+        self.editable = editable
+
+        perms_by_reporter = event.reporters
+        reporter_accounts = Account._byID(perms_by_reporter.keys(), data=True)
+        reporters = [LiveUpdateReporter(account, perms_by_reporter[account._id])
+                     for account in reporter_accounts.itervalues()]
+        reporters.sort(key=lambda r: r.account.name)
+
+        SimpleBuilder.__init__(
+            self,
+            reporters,
+            keep_fn=self.keep_item,
+            wrap=self.wrap_item,
+            skip=False,
+            num=0,
+        )
+
+    def keep_item(self, item):
+        return not item.account._deleted
+
+    def wrap_item(self, item):
+        return pages.ReporterTableItem(
+            item,
+            self.event,
+            editable=self.editable,
+        )
+
+    def wrap_items(self, items):
+        wrapped = []
+        for item in items:
+            wrapped.append(self.wrap_item(item))
+        return wrapped
 
 
 @add_controller
@@ -105,12 +153,13 @@ class LiveUpdateController(RedditController):
         if not c.liveupdate_event:
             self.abort404()
 
-        c.liveupdate_can_manage = (c.liveupdate_event.state == "live" and
-                                   (c.user_is_loggedin and c.user_is_admin))
-        c.liveupdate_can_edit = (c.liveupdate_event.state == "live" and
-                                 (c.user_is_loggedin and
-                                  (c.liveupdate_event.is_reporter(c.user) or
-                                   c.user_is_admin)))
+        if c.user_is_loggedin:
+            c.liveupdate_permissions = \
+                    c.liveupdate_event.get_permissions(c.user)
+            if c.user_is_admin:
+                c.liveupdate_permissions = ReporterPermissionSet.SUPERUSER
+        else:
+            c.liveupdate_permissions = ReporterPermissionSet.NONE
 
     @validate(
         num=VLimit("limit", default=25, max_limit=100),
@@ -153,8 +202,7 @@ class LiveUpdateController(RedditController):
             ).render()
         else:
             # embeds are always logged out and therefore safe for frames.
-            c.liveupdate_can_manage = False
-            c.liveupdate_can_edit = False
+            c.liveupdate_permissions = ReporterPermissionSet.NONE
             c.allow_framing = True
 
             return pages.LiveUpdateEmbed(
@@ -178,7 +226,7 @@ class LiveUpdateController(RedditController):
         ).render()
 
     @validate(
-        VLiveUpdateEventReporter(),
+        VLiveUpdateReporterWithPermission("settings"),
     )
     def GET_edit(self):
         return pages.LiveUpdatePage(
@@ -186,7 +234,7 @@ class LiveUpdateController(RedditController):
         ).render()
 
     @validatedForm(
-        VLiveUpdateEventReporter(),
+        VLiveUpdateReporterWithPermission("settings"),
         VModhash(),
         title=VLength("title", max_length=120),
         description=VMarkdown("description", empty_error=None),
@@ -220,47 +268,69 @@ class LiveUpdateController(RedditController):
 
     # TODO: pass listing params on
     def GET_reporters(self):
-        event = c.liveupdate_event
-        wrapper = lambda user: pages.ReporterTableItem(user, event,
-                                         editable=c.liveupdate_can_edit)
-        accounts = Account._byID(event.reporter_ids,
-                                 data=True, return_dict=False)
-        keep_fn = lambda item: not item.user._deleted
-        b = SimpleBuilder(
-            accounts,
-            keep_fn=keep_fn,
-            wrap=wrapper,
-            skip=True,
-            num=0,
-        )
-        listing = pages.ReporterListing(event, b,
-                          editable=c.liveupdate_can_edit).listing()
+        editable = c.liveupdate_permissions.allow("manage")
+        builder = LiveUpdateReporterBuilder(c.liveupdate_event, editable)
+        listing = pages.ReporterListing(
+            c.liveupdate_event,
+            builder,
+            editable=editable,
+        ).listing()
+
         return pages.LiveUpdatePage(
             content=listing,
         ).render()
 
     @validatedForm(
-        VLiveUpdateEventReporter(),
+        VLiveUpdateReporterWithPermission("manage"),
         VModhash(),
         user=VExistingUname("name"),
+        type_and_perms=VLiveUpdatePermissions("type", "permissions"),
     )
-    def POST_add_reporter(self, form, jquery, user):
+    def POST_add_reporter(self, form, jquery, user, type_and_perms):
         if form.has_errors("name", errors.USER_DOESNT_EXIST,
                                    errors.NO_USER):
             return
+        if form.has_errors("type", errors.INVALID_PERMISSION_TYPE):
+            return
+        if form.has_errors("permissions", errors.INVALID_PERMISSIONS):
+            return
 
-        # make the user able to edit
-        c.liveupdate_event.add_reporter(user)
+        type, permissions = type_and_perms
+        c.liveupdate_event.add_reporter(user, permissions)
 
         # TODO: send PM to new reporter
 
         # add the user to the table
-        user_row = pages.ReporterTableItem(user, c.liveupdate_event)
+        reporter = LiveUpdateReporter(user, permissions)
+        user_row = pages.ReporterTableItem(reporter, c.liveupdate_event,
+                                           editable=True)
         jquery(".liveupdate_reporter-table").show(
             ).find("table").insert_table_rows(user_row)
 
     @validatedForm(
-        VLiveUpdateEventReporter(),
+        VLiveUpdateReporterWithPermission("manage"),
+        VModhash(),
+        user=VExistingUname("name"),
+        type_and_perms=VLiveUpdatePermissions("type", "permissions"),
+    )
+    def POST_set_reporter_permissions(self, form, jquery, user, type_and_perms):
+        if form.has_errors("name", errors.USER_DOESNT_EXIST,
+                                   errors.NO_USER):
+            return
+        if form.has_errors("type", errors.INVALID_PERMISSION_TYPE):
+            return
+        if form.has_errors("permissions", errors.INVALID_PERMISSIONS):
+            return
+
+        type, permissions = type_and_perms
+        c.liveupdate_event.update_reporter_permissions(user, permissions)
+
+        row = form.closest("tr")
+        editor = row.find(".permissions").data("PermissionEditor")
+        editor.onCommit(permissions.dumps())
+
+    @validatedForm(
+        VLiveUpdateReporterWithPermission("manage"),
         VModhash(),
         user=VByName("id", thing_cls=Account),
     )
@@ -268,7 +338,7 @@ class LiveUpdateController(RedditController):
         c.liveupdate_event.remove_reporter(user)
 
     @validatedForm(
-        VLiveUpdateEventReporter(),
+        VLiveUpdateReporterWithPermission("update"),
         VModhash(),
         text=VMarkdown("body", max_length=4096),
     )
@@ -295,7 +365,7 @@ class LiveUpdateController(RedditController):
         t.attr('rows', 3).html("").val("")
 
     @validatedForm(
-        VLiveUpdateEventReporter(),
+        VLiveUpdateReporterWithPermission("edit"),
         VModhash(),
         update=VLiveUpdate("id"),
     )
@@ -309,7 +379,7 @@ class LiveUpdateController(RedditController):
         send_websocket_broadcast(type="delete", payload=update._fullname)
 
     @validatedForm(
-        VLiveUpdateEventReporter(),
+        VLiveUpdateReporterWithPermission("edit"),
         VModhash(),
         update=VLiveUpdate("id"),
     )

--- a/reddit_liveupdate/permissions.py
+++ b/reddit_liveupdate/permissions.py
@@ -1,0 +1,36 @@
+from pylons.i18n import N_
+
+from r2.lib.permissions import PermissionSet
+
+
+class ReporterPermissionSet(PermissionSet):
+    info = {
+        "update": {
+            "title": N_("update"),
+            "description": N_("post updates"),
+        },
+
+        "manage": {
+            "title": N_("manage reporters"),
+            "description": N_("add, remove, and change permissions of reporters"),
+        },
+
+        "settings": {
+            "title": N_("settings"),
+            "description": N_("change the title, description, and timezone"),
+        },
+
+        "edit": {
+            "title": N_("edit"),
+            "description": N_("strike and delete updates"),
+        },
+    }
+
+    def allow(self, permission):
+        if self.is_superuser():
+            return True
+        return self.get(permission, False)
+
+
+ReporterPermissionSet.SUPERUSER = ReporterPermissionSet.loads("+all")
+ReporterPermissionSet.NONE = ReporterPermissionSet.loads("")

--- a/reddit_liveupdate/permissions.py
+++ b/reddit_liveupdate/permissions.py
@@ -22,7 +22,7 @@ class ReporterPermissionSet(PermissionSet):
 
         "edit": {
             "title": N_("edit"),
-            "description": N_("strike and delete updates"),
+            "description": N_("strike and delete others' updates"),
         },
     }
 

--- a/reddit_liveupdate/public/static/js/liveupdate-reporter.js
+++ b/reddit_liveupdate/public/static/js/liveupdate-reporter.js
@@ -3,19 +3,17 @@ r.liveupdate.reporter = {
         this.permissions = new r.liveupdate.PermissionSet(r.config.liveupdate_permissions)
         this.$listing = $('.liveupdate-listing')
 
-        if (this.permissions.allow('edit')) {
-            this.$buttonRow = $(r.templates.make('liveupdate/edit-buttons', {
-                strikeLabel: r._('strike'),
-                deleteLabel: r._('delete')
-            }))
+        this.$buttonRow = $(r.templates.make('liveupdate/edit-buttons', {
+            strikeLabel: r._('strike'),
+            deleteLabel: r._('delete')
+        }))
 
-            this.$listing
-                .on('confirm', '.strike', $.proxy(this, 'strike'))
-                .on('confirm', '.delete', $.proxy(this, 'delete_'))
-                .on('more-updates', $.proxy(this, 'onMoreUpdates'))
+        this.$listing
+            .on('confirm', '.strike', $.proxy(this, 'strike'))
+            .on('confirm', '.delete', $.proxy(this, 'delete_'))
+            .on('more-updates', $.proxy(this, 'onMoreUpdates'))
 
-            this._addButtons(this.$listing.find('tr.thing td'))
-        }
+        this._addButtons(this.$listing.find('tr.thing td'))
     },
 
     onMoreUpdates: function (ev, updates) {
@@ -24,18 +22,22 @@ r.liveupdate.reporter = {
 
     _addButtons: function (updates) {
         updates.each($.proxy(function (index, el) {
-            var $buttonRow = this.$buttonRow.clone()
             var $el = $(el)
+            var author = $el.find('.author').data('name')
 
-            if ($el.thing().hasClass('stricken')) {
-                $buttonRow.find('button.strike').parent().remove()
+            if (this.permissions.allow('edit') || author == r.config.logged) {
+                var $buttonRow = this.$buttonRow.clone()
+
+                if ($el.thing().hasClass('stricken')) {
+                    $buttonRow.find('button.strike').parent().remove()
+                }
+
+                $buttonRow.find('button').each(function (index, el) {
+                    new r.ui.ConfirmButton({'el': el})
+                })
+
+                $el.append($buttonRow)
             }
-
-            $buttonRow.find('button').each(function (index, el) {
-                new r.ui.ConfirmButton({'el': el})
-            })
-
-            $el.append($buttonRow)
         }, this))
     },
 

--- a/reddit_liveupdate/public/static/js/liveupdate-reporter.js
+++ b/reddit_liveupdate/public/static/js/liveupdate-reporter.js
@@ -1,17 +1,21 @@
 r.liveupdate.reporter = {
     init: function () {
+        this.permissions = new r.liveupdate.PermissionSet(r.config.liveupdate_permissions)
         this.$listing = $('.liveupdate-listing')
-        this.$buttonRow = $(r.templates.make('liveupdate/edit-buttons', {
-            strikeLabel: r._('strike'),
-            deleteLabel: r._('delete')
-        }))
 
-        this.$listing
-            .on('confirm', '.strike', $.proxy(this, 'strike'))
-            .on('confirm', '.delete', $.proxy(this, 'delete_'))
-            .on('more-updates', $.proxy(this, 'onMoreUpdates'))
+        if (this.permissions.allow('edit')) {
+            this.$buttonRow = $(r.templates.make('liveupdate/edit-buttons', {
+                strikeLabel: r._('strike'),
+                deleteLabel: r._('delete')
+            }))
 
-        this._addButtons(this.$listing.find('tr.thing td'))
+            this.$listing
+                .on('confirm', '.strike', $.proxy(this, 'strike'))
+                .on('confirm', '.delete', $.proxy(this, 'delete_'))
+                .on('more-updates', $.proxy(this, 'onMoreUpdates'))
+
+            this._addButtons(this.$listing.find('tr.thing td'))
+        }
     },
 
     onMoreUpdates: function (ev, updates) {
@@ -75,6 +79,23 @@ r.liveupdate.reporter = {
                 $(this).remove()
             })
         })
+    }
+}
+
+r.liveupdate.PermissionSet = function (permissions) {
+    this._permissions = permissions
+}
+r.liveupdate.PermissionSet.prototype = {
+    isSuperUser: function () {
+        return !!this._permissions.all
+    },
+
+    allow: function (name) {
+        if (this.isSuperUser()) {
+            return true
+        }
+
+        return !!this._permissions[name]
     }
 }
 

--- a/reddit_liveupdate/public/static/js/liveupdate.js
+++ b/reddit_liveupdate/public/static/js/liveupdate.js
@@ -106,12 +106,10 @@ r.liveupdate = {
         var now = Date.now()
         _.each(data, function (thing) {
             var $newThing = $($.unsafe(thing.data.content))
-            if (r.liveupdate.reporter) {
-                r.liveupdate.reporter._addButtons($newThing.find('td'))
-            }
+            this.$listing.trigger('more-updates', [$newThing])
             $initial.after($newThing)
             r.timetext.refreshOne($newThing.find('time.live'), now)
-        })
+        }, this)
 
         if (!this._pageVisible) {
             this._unreadUpdates += data.length

--- a/reddit_liveupdate/templates/liveupdateaccount.html
+++ b/reddit_liveupdate/templates/liveupdateaccount.html
@@ -1,5 +1,5 @@
 % if not thing.deleted:
-<a href="/user/${thing.name}" class="author id-${thing.fullname}">/u/${thing.name}</a>
+<a href="/user/${thing.name}" class="author id-${thing.fullname}" data-name="${thing.name}">/u/${thing.name}</a>
 % else:
 ${_("[deleted]")}
 % endif

--- a/reddit_liveupdate/templates/liveupdateevent.html
+++ b/reddit_liveupdate/templates/liveupdateevent.html
@@ -32,7 +32,7 @@
 </div>
 </header>
 
-% if c.liveupdate_can_edit:
+% if c.liveupdate_permissions.allow("update"):
 <div id="new-update-form" class="prettyform">
   ${UserText(None, text="", editable=True, creating=True, name="body", have_form=False)}
 

--- a/reddit_liveupdate/templates/liveupdatepage.html
+++ b/reddit_liveupdate/templates/liveupdatepage.html
@@ -10,7 +10,7 @@
     ${parent.javascript_bottom()}
     ${unsafe(js.use("liveupdate"))}
 
-    % if c.liveupdate_can_edit:
+    % if c.liveupdate_permissions:
     ${unsafe(js.use("liveupdate-reporter"))}
     % endif
 </%def>

--- a/reddit_liveupdate/templates/liveupdatereporterpermissions.html
+++ b/reddit_liveupdate/templates/liveupdatereporterpermissions.html
@@ -3,7 +3,7 @@
 <%def name="form_content()">
   %if not thing.embedded:
     <input type="hidden" name="name"
-      value="${thing.user.name if thing.user else ''}" />
+      value="${thing.user.name if thing.user else ''}">
   %endif
   <input type="hidden" name="type" value="${thing.permissions_type}">
   <input type="hidden" name="permissions"

--- a/reddit_liveupdate/templates/liveupdatereporterpermissions.html
+++ b/reddit_liveupdate/templates/liveupdatereporterpermissions.html
@@ -23,7 +23,7 @@
   %if thing.embedded:
     ${form_content()}
   %else:
-    <form method="post" class="setpermissions pretty-form medium-text"
+    <form method="post" class="pretty-form medium-text"
       onsubmit="return post_form(this, 'live/${c.liveupdate_event._id}/set_reporter_permissions')">
       ${form_content()}
       <button type="submit">${_('save')}</button>

--- a/reddit_liveupdate/templates/liveupdatereporterpermissions.html
+++ b/reddit_liveupdate/templates/liveupdatereporterpermissions.html
@@ -1,0 +1,34 @@
+<%namespace file="utils.html" import="error_field"/>
+
+<%def name="form_content()">
+  %if not thing.embedded:
+    <input type="hidden" name="name"
+      value="${thing.user.name if thing.user else ''}" />
+  %endif
+  <input type="hidden" name="type" value="${thing.permissions_type}">
+  <input type="hidden" name="permissions"
+    value="${thing.permissions.dumps()}">
+  %if not thing.embedded:
+    ${error_field("USER_DOESNT_EXIST", "name")}
+    ${error_field("NO_USER", "name")}
+  %endif
+  ${error_field("INVALID_PERMISSION_TYPE", "type")}
+  ${error_field("INVALID_PERMISSIONS", "permissions")}
+  %if not thing.embedded:
+    <span class="status"></span>
+  %endif
+</%def>
+
+<div class="permissions">
+  %if thing.embedded:
+    ${form_content()}
+  %else:
+    <form method="post" class="setpermissions pretty-form medium-text"
+      onsubmit="return post_form(this, 'live/${c.liveupdate_event._id}/set_reporter_permissions')">
+      ${form_content()}
+      <button type="submit">${_('save')}</button>
+    </form>
+  %endif
+  <div class="permission-summary">
+  </div>
+</div>


### PR DESCRIPTION
This adds an architecture for liveupdate reporters having granular permissions. Initially, I've carved up the current actions into some sane-seeming groups.

One major difference here from mod permissions that I'm not sure of is the existence of the "manage reporters" permission.  The equivalent permission for mods is only available to "superuser" (all permission) mods.  I felt like it'd be better to be explicit about permissions, but it is a bit inconsistent.

I think I can roll this out without blocking on any sort of age supremacy like moderator permissions have.  That may end up being necessary, but I think this is sufficient for now. Perhaps there's an alternate, superior, way of handling that kind of dispute anyway?

Like with the [editor -> reporter rename](https://github.com/reddit/reddit-plugin-liveupdate/commit/da9d11882fec76290226cb6270f49bf820d3ae88), I'll manually update existing events to give full permissions to all extant reporters.

:eyeglasses: @chromakode @andre-d (because of the userlisting stuff)
