### PR TITLE
Initial support for embedded media within liveupdates.

### DIFF
--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -13,6 +13,9 @@ class LiveUpdate(Plugin):
         ConfigValue.str: [
             "liveupdate_pixel_domain",
         ],
+        ConfigValue.set: [
+            "liveupdate_embeddable_domains",
+        ],
     }
 
     js = {
@@ -37,6 +40,7 @@ class LiveUpdate(Plugin):
     def add_routes(self, mc):
         mc("/live/:event", controller="liveupdate", action="listing",
            conditions={"function": not_in_sr}, is_embed=False)
+
         mc("/live/:event/embed", controller="liveupdate", action="listing",
            conditions={"function": not_in_sr}, is_embed=True)
 
@@ -49,6 +53,12 @@ class LiveUpdate(Plugin):
 
         mc("/api/live/:event/:action", controller="liveupdate",
            conditions={"function": not_in_sr})
+
+        mc('/mediaembed/liveupdate/:event/:liveupdate',
+           controller="liveupdateembed", action="mediaembeds")
+
+        mc('/mediaembed/liveupdate/:event/:liveupdate/:embed_index',
+           controller="liveupdateembed", action="mediaembed")
 
     def load_controllers(self):
         from reddit_liveupdate.controllers import (

--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -54,9 +54,6 @@ class LiveUpdate(Plugin):
         mc("/api/live/:event/:action", controller="liveupdate",
            conditions={"function": not_in_sr})
 
-        mc('/mediaembed/liveupdate/:event/:liveupdate',
-           controller="liveupdateembed", action="mediaembeds")
-
         mc('/mediaembed/liveupdate/:event/:liveupdate/:embed_index',
            controller="liveupdateembed", action="mediaembed")
 

--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -70,3 +70,9 @@ class LiveUpdate(Plugin):
 
         from reddit_liveupdate import scraper
         scraper.hooks.register_all()
+
+    def declare_queues(self, queues):
+        from r2.config.queues import MessageQueue
+        queues.declare({
+            "liveupdate_q": MessageQueue(bind_to_self=True),
+        })

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -347,28 +347,6 @@ class LiveUpdateEmbedController(MinimalController):
 
     @validate(
         liveupdate=VLiveUpdate('liveupdate'),
-    )
-    def GET_mediaembeds(self, liveupdate):
-        media_objects = getattr(liveupdate, 'media_objects', [])
-
-        response = []
-        for i, media_object in enumerate(media_objects):
-            response.append({
-                "url": media_object['oembed']['url'],
-                "width": media_object['oembed']['width'],
-                "height": media_object['oembed']['height'],
-                "embed_href": (
-                    "//%s/mediaembed/liveupdate/%s/LiveUpdate_%s/%d" % (
-                        g.media_domain, c.liveupdate_event._id,
-                        liveupdate._id, i)
-                    )
-            })
-
-        return self.api_wrapper(response)
-
-
-    @validate(
-        liveupdate=VLiveUpdate('liveupdate'),
         embed_index=VInt('embed_index', min=0)
     )
     def GET_mediaembed(self, liveupdate, embed_index):

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -40,6 +40,7 @@ from reddit_liveupdate.models import (
     LiveUpdateStream,
     ActiveVisitorsByLiveUpdateEvent,
 )
+from reddit_liveupdate.utils import send_event_broadcast
 from reddit_liveupdate.validators import (
     VLiveUpdate,
     VLiveUpdateEventReporter,
@@ -49,9 +50,8 @@ from reddit_liveupdate.validators import (
 )
 
 
-def send_websocket_broadcast(type, payload):
-    websockets.send_broadcast(namespace="/live/" + c.liveupdate_event._id,
-                              type=type, payload=payload)
+def _broadcast(type, payload):
+    send_event_broadcast(c.liveupdate_event._id, type, payload)
 
 
 class LiveUpdateBuilder(QueryBuilder):
@@ -215,7 +215,7 @@ class LiveUpdateController(RedditController):
             changes["title"] = title
         if description != c.liveupdate_event.description:
             changes["description"] = safemarkdown(description, wrap=False)
-        send_websocket_broadcast(type="settings", payload=changes)
+        _broadcast(type="settings", payload=changes)
 
         c.liveupdate_event.title = title
         c.liveupdate_event.description = description
@@ -295,7 +295,7 @@ class LiveUpdateController(RedditController):
         builder = LiveUpdateBuilder(None)
         wrapped = builder.wrap_items([update])
         rendered = [w.render() for w in wrapped]
-        send_websocket_broadcast(type="update", payload=rendered)
+        _broadcast(type="update", payload=rendered)
 
         # reset the submission form
         t = form.find("textarea")
@@ -313,7 +313,7 @@ class LiveUpdateController(RedditController):
         update.deleted = True
         LiveUpdateStream.add_update(c.liveupdate_event, update)
 
-        send_websocket_broadcast(type="delete", payload=update._fullname)
+        _broadcast(type="delete", payload=update._fullname)
 
     @validatedForm(
         VLiveUpdateEventReporter(),
@@ -327,7 +327,7 @@ class LiveUpdateController(RedditController):
         update.stricken = True
         LiveUpdateStream.add_update(c.liveupdate_event, update)
 
-        send_websocket_broadcast(type="strike", payload=update._fullname)
+        _broadcast(type="strike", payload=update._fullname)
 
 
 @add_controller

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -362,6 +362,10 @@ class LiveUpdateEmbedController(MinimalController):
             abort(404)
 
         embed = get_media_embed(media_object)
+
+        if not embed:
+            abort(404)
+
         content = embed.content
         c.allow_framing = True
 

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -5,11 +5,17 @@ from pylons import g, c, request, response
 from pylons.i18n import _
 
 from r2.controllers import add_controller
-from r2.controllers.reddit_base import RedditController, base_listing
+from r2.controllers.reddit_base import (
+    MinimalController,
+    RedditController,
+    base_listing
+)
 from r2.lib import websockets
 from r2.lib.base import BaseController, abort
 from r2.lib.db import tdb_cassandra
 from r2.lib.filters import safemarkdown
+from r2.lib.media import get_media_embed
+from r2.lib.pages import MediaEmbedBody
 from r2.lib.validator import (
     validate,
     validatedForm,
@@ -21,6 +27,7 @@ from r2.lib.validator import (
     VLimit,
     VMarkdown,
     VModhash,
+    VInt,
 )
 from r2.models import QueryBuilder, Account, LinkListing, SimpleBuilder
 from r2.lib.errors import errors
@@ -321,3 +328,68 @@ class LiveUpdateController(RedditController):
         LiveUpdateStream.add_update(c.liveupdate_event, update)
 
         send_websocket_broadcast(type="strike", payload=update._fullname)
+
+
+@add_controller
+class LiveUpdateEmbedController(MinimalController):
+    def __before__(self, event):
+        MinimalController.__before__(self)
+
+        if event:
+            try:
+                c.liveupdate_event = LiveUpdateEvent._byID(event)
+            except tdb_cassandra.NotFound:
+                pass
+
+        if not c.liveupdate_event:
+            self.abort404()
+
+
+    @validate(
+        liveupdate=VLiveUpdate('liveupdate'),
+    )
+    def GET_mediaembeds(self, liveupdate):
+        media_objects = getattr(liveupdate, 'media_objects', [])
+
+        response = []
+        for i, media_object in enumerate(media_objects):
+            response.append({
+                "url": media_object['oembed']['url'],
+                "width": media_object['oembed']['width'],
+                "height": media_object['oembed']['height'],
+                "embed_href": (
+                    "//%s/mediaembed/liveupdate/%s/LiveUpdate_%s/%d" % (
+                        g.media_domain, c.liveupdate_event._id,
+                        liveupdate._id, i)
+                    )
+            })
+
+        return self.api_wrapper(response)
+
+
+    @validate(
+        liveupdate=VLiveUpdate('liveupdate'),
+        embed_index=VInt('embed_index', min=0)
+    )
+    def GET_mediaembed(self, liveupdate, embed_index):
+        # TODO: Using the raw index on this feels pretty gross but works
+        # fine with this implementation. Should I stuff a UUID in there
+        # for future proofing instead?
+
+        if c.errors or request.host != g.media_domain:
+            # don't serve up untrusted content except on our
+            # specifically untrusted domain
+            abort(404)
+
+        media_objects = getattr(liveupdate, 'media_objects', [])
+
+        try:
+            media_object = media_objects[embed_index]
+        except IndexError:
+            abort(404)
+
+        media_embed = get_media_embed(media_object)
+        content = media_embed.content
+        c.allow_framing = True
+
+        return MediaEmbedBody(body=content).render()

--- a/reddit_liveupdate/models.py
+++ b/reddit_liveupdate/models.py
@@ -158,7 +158,7 @@ class LiveUpdate(object):
     defaults = {
         "deleted": False,
         "stricken": False,
-        "media_objects": [], # Are multi-value objects an antipattern?
+        "media_objects": [],
     }
 
     def __init__(self, id=None, data=None):
@@ -197,6 +197,20 @@ class LiveUpdate(object):
     @property
     def _fullname(self):
         return "%s_%s" % (self.__class__.__name__, self._id)
+
+    @property
+    def _embeds(self):
+        """ Return the media objects in a whitelisted format friendly for
+            rendering as json to the user. """
+
+        embeds = []
+        for media_object in self.media_objects:
+            embeds.append({
+                "url": media_object['oembed']['url'],
+                "width": media_object['oembed']['width'],
+                "height": media_object['oembed']['height'] or 600,
+            })
+        return embeds
 
 
 class ActiveVisitorsByLiveUpdateEvent(tdb_cassandra.View):

--- a/reddit_liveupdate/models.py
+++ b/reddit_liveupdate/models.py
@@ -115,8 +115,7 @@ class LiveUpdateStream(tdb_cassandra.View):
     @classmethod
     def parse_embeds(cls, event_id, liveupdate_id, maxwidth=485):
         """ Parse a liveupdate body, find embed-friendly URLs, scrape their
-            embeds, update the embeds dict, and send an event notifying
-            frontends of the new embeds for the update.
+            embeds, and update the embeds dict.
 
             Return the newly altered liveupdate.
         """
@@ -205,7 +204,7 @@ class LiveUpdate(object):
             embeds.append({
                 "url": media_object['oembed']['url'],
                 "width": media_object['oembed']['width'],
-                "height": media_object['oembed']['height'] or 600,
+                "height": media_object['oembed']['height'],
             })
         return embeds
 

--- a/reddit_liveupdate/models.py
+++ b/reddit_liveupdate/models.py
@@ -117,6 +117,8 @@ class LiveUpdateStream(tdb_cassandra.View):
         """ Parse a liveupdate body, find embed-friendly URLs, scrape their
             embeds, update the embeds dict, and send an event notifying
             frontends of the new embeds for the update.
+
+            Return the newly altered liveupdate.
         """
         if isinstance(liveupdate_id, basestring):
             liveupdate_id = uuid.UUID(liveupdate_id)
@@ -132,6 +134,8 @@ class LiveUpdateStream(tdb_cassandra.View):
         urls = embeddable_urls(liveupdate.body)
         liveupdate.media_objects = generate_media_objects(urls)
         LiveUpdateStream.add_update(event, liveupdate, parse_embeds=False)
+
+        return liveupdate
 
     @classmethod
     def _obj_to_column(cls, entries):
@@ -192,7 +196,7 @@ class LiveUpdate(object):
         return "%s_%s" % (self.__class__.__name__, self._id)
 
     @property
-    def _embeds(self):
+    def embeds(self):
         """ Return the media objects in a whitelisted format friendly for
             rendering as json to the user. """
 

--- a/reddit_liveupdate/models.py
+++ b/reddit_liveupdate/models.py
@@ -5,12 +5,14 @@ import uuid
 
 import pytz
 
+from pylons import g
+
 from pycassa.util import convert_uuid_to_time
 from pycassa.system_manager import TIME_UUID_TYPE, UTF8_TYPE
 
 from r2.lib.db import tdb_cassandra
 from r2.lib import utils
-
+from r2.lib.media import Scraper
 
 class LiveUpdateEvent(tdb_cassandra.Thing):
     _reporter_prefix = "reporter_"
@@ -82,9 +84,12 @@ class LiveUpdateStream(tdb_cassandra.View):
     }
 
     @classmethod
-    def add_update(cls, event, update):
+    def add_update(cls, event, update, parse_embeds=True):
         columns = cls._obj_to_column(update)
         cls._set_values(event._id, columns)
+        if parse_embeds:
+            cls._parse_update_embeds(event, update)
+
 
     @classmethod
     def get_update(cls, event, id):
@@ -96,6 +101,44 @@ class LiveUpdateStream(tdb_cassandra.View):
             raise tdb_cassandra.NotFound, "<LiveUpdate %s>" % id
         else:
             return LiveUpdate.from_json(id, data)
+
+    @classmethod
+    def _parse_update_embeds(cls, event, update):
+        """ Parse an updates body, find embed-friendly URLs, scrape their
+            embeds and update the embeds dict.
+        """
+
+        urls = [u for u in utils.extract_urls_from_markdown(update.body)
+                if utils.domain(u) in g.liveupdate_embeddable_domains]
+
+        media_objects = []
+        embed_count = 0
+        for url in urls:
+            # Too many embeds, this could be a DoS attempt or something. Just
+            # bail on any more embeds for this update.
+            if embed_count > 15:
+                return
+
+            scraper = Scraper.for_url(url)
+            scraper.maxwidth = 485
+
+            thumbnail, media_object, secure_media_object = scraper.scrape()
+            if media_object:
+                embed_count += 1
+                # Use our exact passed URL to ensure matching in markdown.
+                # Some scrapers will canonicalize a URL to something we
+                # haven't seen yet.
+                media_object['oembed']['url'] = url
+                media_objects.append(media_object)
+
+        update.media_objects = media_objects
+
+        # Todo: I don't really like re-using add_update here with a flag,
+        # but I'm not sure of a better way to save this. Looks like strike
+        # and other edits use this too. Thoughts on this appreciated.
+        # Todo on this todo: remove it and make it a comment on the PR.
+        cls.add_update(event, update, parse_embeds=False)
+
 
     @classmethod
     def _obj_to_column(cls, entries):
@@ -115,6 +158,7 @@ class LiveUpdate(object):
     defaults = {
         "deleted": False,
         "stricken": False,
+        "media_objects": [], # Are multi-value objects an antipattern?
     }
 
     def __init__(self, id=None, data=None):

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -36,9 +36,14 @@ class LiveUpdatePage(Reddit):
     extra_stylesheets = Reddit.extra_stylesheets + ["liveupdate.less"]
 
     def __init__(self, content, websocket_url=None):
+        # Convert set to list for JSON serializing
+        embeddable_domains = list(g.liveupdate_embeddable_domains)
+
         extra_js_config = {
             "liveupdate_event": c.liveupdate_event._id,
             "liveupdate_pixel_domain": g.liveupdate_pixel_domain,
+            "media_domain": g.media_domain,
+            "liveupdate_embeddable_domains": embeddable_domains
         }
 
         if websocket_url:

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -8,7 +8,7 @@ from pylons import c, g
 from pylons.i18n import _, ungettext
 
 from r2.lib import filters
-from r2.lib.pages import Reddit, UserTableItem
+from r2.lib.pages import Reddit, UserTableItem, MediaEmbedBody
 from r2.lib.menus import NavMenu, NavButton
 from r2.lib.template_helpers import add_sr
 from r2.lib.memoize import memoize
@@ -302,6 +302,10 @@ class LiveUpdateListing(Listing):
             items.append(update)
 
         return items
+
+
+class LiveUpdateMediaEmbedBody(MediaEmbedBody):
+    pass
 
 
 def liveupdate_add_props(user, wrapped):

--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -228,6 +228,10 @@ body.embed .infobar.welcome {
     }
 }
 
+.embedFrame {
+    border: 0;
+}
+
 #noresults {
     margin-top: 10px;
 }

--- a/reddit_liveupdate/public/static/js/liveupdate.js
+++ b/reddit_liveupdate/public/static/js/liveupdate.js
@@ -25,7 +25,8 @@ r.liveupdate = {
                 'message:activity': this._onActivityUpdated,
                 'message:refresh': this._onRefresh,
                 'message:settings': this._onSettingsChanged,
-                'message:update': this._onNewUpdate
+                'message:update': this._onNewUpdate,
+                'message:render_embeds': this._onRenderEmbeds
             }, this)
             this._websocket.start()
         }
@@ -119,6 +120,14 @@ r.liveupdate = {
             this._unreadUpdates += data.length
             Tinycon.setBubble(this._unreadUpdates)
         }
+    },
+
+    _onRenderEmbeds: function (data) {
+        $('tr.id-LiveUpdate_' + data.liveupdate_id)
+            .data('embeds', data.media_embeds)
+            .addClass('pending-embed')
+
+        $(window).trigger('liveupdate:refreshEmbeds')
     },
 
     _onDelete: function (id) {
@@ -325,7 +334,7 @@ _.extend(r.liveupdate.EmbedViewer.prototype, {
 
     _listen: function() {
         $('tr[data-embeds]').addClass('pending-embed');
-       $(window).on('load resize scroll', $.proxy(this, '_renderVisibleEmbeds'))
+       $(window).on('load resize scroll liveupdate:refreshEmbeds', $.proxy(this, '_renderVisibleEmbeds'))
     },
 
     init: function() {

--- a/reddit_liveupdate/public/static/js/liveupdate.js
+++ b/reddit_liveupdate/public/static/js/liveupdate.js
@@ -6,6 +6,7 @@ r.liveupdate = {
         this.$listing = $('.liveupdate-listing')
         this.$table = this.$listing.find('table tbody')
         this.$statusField = this.$listing.find('tr.initial td')
+        this._embedViewer = new r.liveupdate.EmbedViewer()
 
         this.$listing.find('nav.nextprev').remove()
         $(window)
@@ -42,6 +43,7 @@ r.liveupdate = {
 
         this._pixelsFetched = 0
         this._fetchPixel()
+        this._embedViewer.init()
     },
 
     _onPageVisible: function () {
@@ -253,5 +255,100 @@ _.extend(r.liveupdate.Countdown.prototype, {
         }
     }
 })
+
+/**
+ * EmbedViewer displays matching embeddable links inline nicely for live updates (like tweets).
+ * Workflow:
+ * 1. On load of new listings, match the links within each of them to see if they have matching domains for potential
+ *    embedding (or RE's depending on lookup time.)
+ * 2. For each of those links, flag them to load the embed on visibility in the viewport.
+ * 3. On visibility in the viewport replace the matching link with the associated embed.
+**/
+r.liveupdate.EmbedViewer = function() {
+}
+
+_.extend(r.liveupdate.EmbedViewer.prototype, {
+    /**
+     * domains of every potentially embeddable domain. We use this for matching to determine if we should pull
+     * any possible embeds for this update. Used with an object with keys for fast matching.
+    **/
+    _embedDomains: _.object(r.config.liveupdate_embeddable_domains, true),
+    _embedBase: '//' + r.config.media_domain + '/mediaembed/liveupdate/' + r.config.liveupdate_event,
+
+    /** Borrowed from http://stackoverflow.com/a/7557433 **/
+    _isElementInViewport: function(el) {
+        var rect = el.getBoundingClientRect()
+
+        return (
+            rect.top >= 0 &&
+            rect.left >= 0 &&
+            rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+            rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+        )
+    },
+
+    /**
+     * Given an embeddable link, replace it with the embed associated with it.
+     * Todo: This currently will make 2N requests per update if an update has multiple embeds, as it will repeat
+     * the first call to get all of the embeds for an update. We should probably make this be update-based
+     * rather than link-based.
+    **/
+    _renderEmbed: function(el) {
+        var updateId = $(el).parents('tr').data('fullname')
+            embedsUri = this._embedBase + '/' + updateId
+
+        $.getJSON(embedsUri, function(response) {
+            var embed = _.findWhere(response, {url: el.href})
+            if (embed) {
+                /* Todo: We need to make height dynamic using postMessage. */
+                var iframe = $('<iframe />').attr({
+                    'class': 'embedFrame',
+                    'src': embed.embed_href,
+                    'width': embed.width,
+                    'height': embed.height || 600
+                })
+                $(el).replaceWith(iframe)
+            }
+        })
+    },
+
+    /**
+     * Look for embeds in the viewport that have yet to be rendered, render
+     * and flag them.
+    **/
+    _renderVisibleEmbeds: function() {
+        $('a.pending-embed').each(_.bind(function(i, el) {
+            if (this._isElementInViewport(el)) {
+                $(el).removeClass('pending-embed')
+                this._renderEmbed(el)
+            }
+        }, this))
+    },
+
+    /**
+     * Find all links in usertext body. For each of them, determine if they are embeddable, and flag them to be
+     * embedded if so.
+    */
+    _bindToLinks: function() {
+        var $listingLinks = $('.liveupdate-listing .usertext-body a')
+
+        $listingLinks.each(_.bind(function(i, el) {
+            var domain = el.hostname.replace(/^www\./,'')
+            if (_.has(this._embedDomains, domain)) {
+                $(el).addClass('pending-embed')
+            }
+        }, this))
+    },
+
+    _listen: function() {
+       this._bindToLinks()
+       $(window).on('load resize scroll', $.proxy(this, '_renderVisibleEmbeds'))
+    },
+
+    init: function() {
+        this._listen()
+    }
+})
+
 
 r.liveupdate.init()

--- a/reddit_liveupdate/queue.py
+++ b/reddit_liveupdate/queue.py
@@ -3,11 +3,24 @@ import json
 from pylons import g
 from r2.lib import amqp
 from reddit_liveupdate.models import LiveUpdateStream
+from reddit_liveupdate.utils import send_event_broadcast
+
+
+def _parse_embeds(event_id, liveupdate_id, maxwidth=485):
+    liveupdate = LiveUpdateStream.parse_embeds(event_id,
+                                               liveupdate_id,
+                                               maxwidth)
+
+    payload = {
+        "liveupdate_id": liveupdate_id,
+        "media_embeds": liveupdate.embeds
+    }
+    send_event_broadcast(event_id, type="render_embeds", payload=payload)
 
 
 def process_liveupdate_q():
     _handlers = {
-        "parse_embeds": LiveUpdateStream.parse_embeds,
+        "parse_embeds": _parse_embeds,
     }
 
     @g.stats.amqp_processor('liveupdate_q')

--- a/reddit_liveupdate/queue.py
+++ b/reddit_liveupdate/queue.py
@@ -1,0 +1,23 @@
+import json
+
+from pylons import g
+from r2.lib import amqp
+from reddit_liveupdate.models import LiveUpdateStream
+
+
+def process_liveupdate_q():
+    _handlers = {
+        "parse_embeds": LiveUpdateStream.parse_embeds,
+    }
+
+    @g.stats.amqp_processor('liveupdate_q')
+    def _handle_liveupdate_q(msg):
+        data = json.loads(msg.body)
+        action = data.pop('action')
+
+        if action in _handlers:
+            _handlers[action](**data)
+        else:
+            g.log.debug("Unknown action %s. Data: %s" % action, data)
+
+    amqp.consume_items('liveupdate_q', _handle_liveupdate_q, verbose=False)

--- a/reddit_liveupdate/templates/liveupdate.html
+++ b/reddit_liveupdate/templates/liveupdate.html
@@ -1,5 +1,6 @@
 <%!
 
+  import json
   from r2.lib.template_helpers import html_datetime
   from babel.dates import format_datetime
 
@@ -8,15 +9,13 @@
 <%namespace file="utils.html" name="utils" />
 <%namespace file="printablebuttons.html" import="ynbutton" />
 
-<tr data-fullname="${thing._fullname}" class="thing id-${thing._fullname} ${"stricken" if thing.stricken else ""}">
+<tr data-fullname="${thing._fullname}" data-embeds="${json.dumps(thing._embeds)}" class="thing id-${thing._fullname} ${"stricken" if thing.stricken else ""}">
   <th scope="row">
     <time title="${format_datetime(thing._date, format='long', tzinfo=c.liveupdate_event.timezone, locale=c.locale)}" datetime="${html_datetime(thing._date)}" class="live">${thing.date_str}</time>
   </th>
 
   <td class="md">
-    <div class="usertext-body">
     ${utils.md(thing.body)}
-    </div>
     ${thing.author}
   </td>
 </tr>

--- a/reddit_liveupdate/templates/liveupdate.html
+++ b/reddit_liveupdate/templates/liveupdate.html
@@ -9,7 +9,7 @@
 <%namespace file="utils.html" name="utils" />
 <%namespace file="printablebuttons.html" import="ynbutton" />
 
-<tr data-fullname="${thing._fullname}" data-embeds="${json.dumps(thing.embeds)}" class="thing id-${thing._fullname} ${"stricken" if thing.stricken else ""}">
+<tr data-fullname="${thing._fullname}" data-embeds="${json.dumps(thing.embeds)}" class="thing id-${thing._fullname} ${"stricken" if thing.stricken else ""} ${"pending-embed" if thing.embeds else ""}">
   <th scope="row">
     <time title="${format_datetime(thing._date, format='long', tzinfo=c.liveupdate_event.timezone, locale=c.locale)}" datetime="${html_datetime(thing._date)}" class="live">${thing.date_str}</time>
   </th>

--- a/reddit_liveupdate/templates/liveupdate.html
+++ b/reddit_liveupdate/templates/liveupdate.html
@@ -14,7 +14,9 @@
   </th>
 
   <td class="md">
+    <div class="usertext-body">
     ${utils.md(thing.body)}
+    </div>
     ${thing.author}
   </td>
 </tr>

--- a/reddit_liveupdate/templates/liveupdate.html
+++ b/reddit_liveupdate/templates/liveupdate.html
@@ -9,7 +9,7 @@
 <%namespace file="utils.html" name="utils" />
 <%namespace file="printablebuttons.html" import="ynbutton" />
 
-<tr data-fullname="${thing._fullname}" data-embeds="${json.dumps(thing._embeds)}" class="thing id-${thing._fullname} ${"stricken" if thing.stricken else ""}">
+<tr data-fullname="${thing._fullname}" data-embeds="${json.dumps(thing.embeds)}" class="thing id-${thing._fullname} ${"stricken" if thing.stricken else ""}">
   <th scope="row">
     <time title="${format_datetime(thing._date, format='long', tzinfo=c.liveupdate_event.timezone, locale=c.locale)}" datetime="${html_datetime(thing._date)}" class="live">${thing.date_str}</time>
   </th>

--- a/reddit_liveupdate/templates/liveupdatemediaembedbody.html
+++ b/reddit_liveupdate/templates/liveupdatemediaembedbody.html
@@ -1,0 +1,61 @@
+## The contents of this file are subject to the Common Public Attribution
+## License Version 1.0. (the "License"); you may not use this file except in
+## compliance with the License. You may obtain a copy of the License at
+## http://code.reddit.com/LICENSE. The License is based on the Mozilla Public
+## License Version 1.1, but Sections 14 and 15 have been added to cover use of
+## software over a computer network and provide for limited attribution for the
+## Original Developer. In addition, Exhibit A has been modified to be
+## consistent with Exhibit B.
+##
+## Software distributed under the License is distributed on an "AS IS" basis,
+## WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License for
+## the specific language governing rights and limitations under the License.
+##
+## The Original Code is reddit.
+##
+## The Original Developer is the Initial Developer.  The Initial Developer of
+## the Original Code is reddit Inc.
+##
+## All portions of the code written by reddit are Copyright (c) 2006-2013
+## reddit Inc. All Rights Reserved.
+###############################################################################
+
+<!doctype html>
+<html>
+  <head>
+    <style type="text/css">
+        body, object, embed, div, span, p {
+            margin:  0;
+            padding: 0;
+        }
+    </style>
+  </head>
+  <body data-update-id="${thing.liveupdate_id}" data-embed-index="${thing.embed_index}">
+      ${unsafe(thing.body)}
+
+      % if thing.unknown_dimensions:
+      <script type="text/javascript">
+      var updateId = document.body.getAttribute('data-update-id'),
+          embedIndex = document.body.getAttribute('data-embed-index');
+
+      function _postmsg(msg, targetOrigin) {
+        /* TODO: Better origin checking? Do we care for these messages? */
+        targetOrigin = targetOrigin || '*';
+        if (window.parent) {
+            window.parent.postMessage(JSON.stringify(msg), targetOrigin);
+        }
+      }
+
+      var knownDimensions = "0x0";
+      window.setInterval(function() {
+        var root = document.documentElement,
+            dimensions = root.offsetWidth + 'x' + root.offsetHeight;
+        if (knownDimensions !== dimensions) {
+            knownDimensions = dimensions;
+            _postmsg({"action": "dimensionsChange", "dimensions": knownDimensions, "updateId": updateId, "embedIndex": embedIndex});
+        }
+      }, 500);
+      </script>
+      % endif
+  </body>
+</html>

--- a/reddit_liveupdate/templates/liveupdatemediaembedbody.html
+++ b/reddit_liveupdate/templates/liveupdatemediaembedbody.html
@@ -22,40 +22,41 @@
 
 <!doctype html>
 <html>
-  <head>
+<head>
     <style type="text/css">
-        body, object, embed, div, span, p {
-            margin:  0;
-            padding: 0;
-        }
+    html, iframe, body, object, embed, div, span, p {
+        margin: 0;
+        padding: 0;
+    }
     </style>
-  </head>
-  <body data-update-id="${thing.liveupdate_id}" data-embed-index="${thing.embed_index}">
-      ${unsafe(thing.body)}
+</head>
+<body data-update-id="${thing.liveupdate_id}" data-embed-index="${thing.embed_index}">
+    ${unsafe(thing.body)}
+    % if thing.unknown_dimensions:
+    <script type="text/javascript">
+    var updateId = document.body.getAttribute('data-update-id'),
+        embedIndex = document.body.getAttribute('data-embed-index');
 
-      % if thing.unknown_dimensions:
-      <script type="text/javascript">
-      var updateId = document.body.getAttribute('data-update-id'),
-          embedIndex = document.body.getAttribute('data-embed-index');
+    if (window.parent) {
+        var knownDimensions = "0x0";
+        window.setInterval(function() {
+            var root = document.documentElement,
+                dimensions = root.offsetWidth + 'x' + root.offsetHeight;
 
-      function _postmsg(msg, targetOrigin) {
-        /* TODO: Better origin checking? Do we care for these messages? */
-        targetOrigin = targetOrigin || '*';
-        if (window.parent) {
-            window.parent.postMessage(JSON.stringify(msg), targetOrigin);
-        }
-      }
+            if (knownDimensions === dimensions) {
+                return;
+            }
 
-      var knownDimensions = "0x0";
-      window.setInterval(function() {
-        var root = document.documentElement,
-            dimensions = root.offsetWidth + 'x' + root.offsetHeight;
-        if (knownDimensions !== dimensions) {
             knownDimensions = dimensions;
-            _postmsg({"action": "dimensionsChange", "dimensions": knownDimensions, "updateId": updateId, "embedIndex": embedIndex});
-        }
-      }, 500);
-      </script>
-      % endif
-  </body>
+            window.parent.postMessage(JSON.stringify({
+                "action": "dimensionsChange",
+                "dimensions": knownDimensions,
+                "updateId": updateId,
+                "embedIndex": embedIndex
+            }), '*');
+        }, 500);
+    }
+    </script>
+    % endif
+</body>
 </html>

--- a/reddit_liveupdate/utils.py
+++ b/reddit_liveupdate/utils.py
@@ -4,7 +4,9 @@ import itertools
 import pytz
 
 from babel.dates import format_time, format_datetime
-from pylons import c
+from pylons import c, g
+from r2.lib.media import Scraper
+from r2.lib.utils import extract_urls_from_markdown, domain
 
 
 def pairwise(iterable):
@@ -39,3 +41,34 @@ def pretty_time(dt):
             format="dd MMM YYYY HH:mm z",
             locale=c.locale,
         )
+
+
+def embeddable_urls(md):
+    """ Given some markdown, return a list of all URLs that are from
+        liveupdate-embeddable domains.
+    """
+    return [u for u in extract_urls_from_markdown(md)
+            if domain(u) in g.liveupdate_embeddable_domains]
+
+
+def generate_media_objects(urls, maxwidth=485, max_embeds=15):
+    """ Given a list of embed URLs, scrape and return their media objects. """
+    media_objects = []
+    for url in urls:
+        scraper = Scraper.for_url(url)
+        scraper.maxwidth = maxwidth
+
+        # TODO: Is there a situation in which we would need the secure media
+        # object? Are twitter/youtube/imgur appropriately protocol agnostic?
+        thumbnail, media_object, secure_media_object = scraper.scrape()
+        if media_object and 'oembed' in media_object:
+            # Use our exact passed URL to ensure matching in markdown.
+            # Some scrapers will canonicalize a URL to something we
+            # haven't seen yet.
+            media_object['oembed']['url'] = url
+            media_objects.append(media_object)
+
+        if len(media_objects) > max_embeds:
+            break
+
+    return media_objects

--- a/reddit_liveupdate/utils.py
+++ b/reddit_liveupdate/utils.py
@@ -5,6 +5,7 @@ import pytz
 
 from babel.dates import format_time, format_datetime
 from pylons import c, g
+from r2.lib import websockets
 from r2.lib.media import Scraper
 from r2.lib.utils import extract_urls_from_markdown, domain
 
@@ -41,6 +42,13 @@ def pretty_time(dt):
             format="dd MMM YYYY HH:mm z",
             locale=c.locale,
         )
+
+
+def send_event_broadcast(event_id, type, payload):
+    """ Send a liveupdate broadcast for a specific event. """
+    websockets.send_broadcast(namespace="/live/" + event_id,
+                              type=type,
+                              payload=payload)
 
 
 def embeddable_urls(md):

--- a/upstart/reddit-consumer-liveupdate_q.conf
+++ b/upstart/reddit-consumer-liveupdate_q.conf
@@ -1,0 +1,15 @@
+description "consume async events from the liveupdate_q"
+
+instance $x
+
+stop on reddit-stop or runlevel [016]
+
+respawn
+respawn limit 10 5
+
+nice 10
+script
+    . /etc/default/reddit
+    wrap-job paster run --proctitle liveupdate_q$x $REDDIT_INI -c 'from reddit_liveupdate.queue import process_liveupdate_q; process_liveupdate_q()'
+end script
+


### PR DESCRIPTION
:eyeglasses: @spladug @chromakode

Note: Companion PR into reddit proper required first for config support for sets!

You'll also want to set `liveupdate_embeddable_domains` in your development.update. I've got mine set to: 

```
liveupdate_embeddable_domains = youtube.com, youtu.be, twitter.com, t.co, imgur.com, flickr.com, flic.kr
```

OK guys, here's a first cut of what embedded media is looking like. There's still a number of open questions but I wanted to get this to you before I left for the week.

Some open issues:
- You won't be able to use twitter embeds yet, as that requires the TwitterScraper that I haven't PR'ed yet. I've got it written and it works, biggest decision is whether we should make it only work for live or make it used on reddit proper as well. Any thoughts on that? Youtube should work just fine though, you can play with that if you're testing.
- Heights of iframes are going to be a problem with twitter (their heights are dynamic), so we're going to need to need to set the height of the iframe dynamically ourselves (probably using postMessage)
- There's a bunch of stuff that I'm still not sure on, things like how to best handle individual embeds. Right now it's a multi-value list just on the update itself, which means I'm using raw indexes to get at them in the URI. That seems kinda gross to me from a relational standpoint but I'm not sure if it's "normal" schemaless wise.

I'd love any feedback on all of this, especially if I'm doing things weirdly in terms of the way y'all do things or how to use plugins! I think I'm getting my footing a bit more but there's a lot to cover. ;) Please be harsh!
