### PR TITLE
Media embeds, take three

### DIFF
--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -28,6 +28,7 @@ class LiveUpdate(Plugin):
             "lib/tinycon.js",
             "websocket.js",
             "timetext.js",
+            "scrollupdater.js",
             "liveupdate.js",
         ),
         "liveupdate-reporter": LocalizedModule("liveupdate-reporter.js",
@@ -46,6 +47,7 @@ class LiveUpdate(Plugin):
     def add_routes(self, mc):
         mc("/live/:event", controller="liveupdate", action="listing",
            conditions={"function": not_in_sr}, is_embed=False)
+
         mc("/live/:event/embed", controller="liveupdate", action="listing",
            conditions={"function": not_in_sr}, is_embed=True)
 
@@ -58,6 +60,9 @@ class LiveUpdate(Plugin):
 
         mc("/api/live/:event/:action", controller="liveupdate",
            conditions={"function": not_in_sr})
+
+        mc('/mediaembed/liveupdate/:event/:liveupdate/:embed_index',
+           controller="liveupdateembed", action="mediaembed")
 
     def load_controllers(self):
         from reddit_liveupdate.controllers import (
@@ -72,3 +77,9 @@ class LiveUpdate(Plugin):
 
         from reddit_liveupdate import scraper
         scraper.hooks.register_all()
+
+    def declare_queues(self, queues):
+        from r2.config.queues import MessageQueue
+        queues.declare({
+            "liveupdate_scraper_q": MessageQueue(bind_to_self=True),
+        })

--- a/reddit_liveupdate/media_embeds.py
+++ b/reddit_liveupdate/media_embeds.py
@@ -1,0 +1,215 @@
+import json
+import re
+import uuid
+
+from urllib2 import (
+    HTTPError,
+    URLError,
+)
+
+import requests
+
+from pylons import g
+
+from r2.lib import amqp
+from r2.lib.db import tdb_cassandra
+from r2.lib.media import MediaEmbed, Scraper, get_media_embed
+from r2.lib.utils import sanitize_url
+
+from reddit_liveupdate.models import LiveUpdateStream, LiveUpdateEvent
+from reddit_liveupdate.utils import send_event_broadcast
+
+
+def get_live_media_embed(media_object):
+    if media_object['type'] == "twitter.com":
+        return _TwitterScraper.media_embed(media_object)
+    return get_media_embed(media_object)
+
+
+def queue_parse_embeds(event, liveupdate):
+    msg = json.dumps({
+        'liveupdate_id': unicode(liveupdate._id),  # serializing UUID
+        'event_id': event._id,  # Already a string
+    })
+    amqp.add_item('liveupdate_scraper_q', msg)
+
+
+def parse_embeds(event_id, liveupdate_id, maxwidth=485):
+    """Find, scrape, and store any embeddable URLs in this liveupdate.
+
+    Return the newly altered liveupdate for convenience.
+    Note: This should be used in async contexts only.
+
+    """
+    if isinstance(liveupdate_id, basestring):
+        liveupdate_id = uuid.UUID(liveupdate_id)
+
+    try:
+        event = LiveUpdateEvent._byID(event_id)
+        liveupdate = LiveUpdateStream.get_update(event, liveupdate_id)
+    except tdb_cassandra.NotFound:
+        g.log.warning("Couldn't find event/liveupdate for embedding: %r / %r",
+                      event_id, liveupdate_id)
+        return
+
+    urls = _extract_isolated_urls(liveupdate.body)
+    liveupdate.media_objects = _scrape_media_objects(urls)
+    LiveUpdateStream.add_update(event, liveupdate)
+
+    return liveupdate
+
+
+def _extract_isolated_urls(md):
+    """Extract URLs that exist on their own lines in given markdown.
+
+    This style borrowed from wordpress, which is nice because it's tolerant to
+    failures and is easy to understand. See https://codex.wordpress.org/Embeds
+
+    """
+    urls = []
+    for line in md.splitlines():
+        url = sanitize_url(line, require_scheme=True)
+        if url and url != "self":
+            urls.append(url)
+    return urls
+
+
+def _scrape_media_objects(urls, autoplay=False, maxwidth=485, max_urls=3):
+    """Given a list of URLs, scrape and return the valid media objects."""
+    return filter(None, (_scrape_media_object(url,
+                                              autoplay=autoplay,
+                                              maxwidth=maxwidth)
+                         for url in urls[:max_urls]))
+
+
+def _scrape_media_object(url, autoplay=False, maxwidth=485):
+    """Generate a single media object by URL. Returns None on failure."""
+    scraper = LiveScraper.for_url(url, autoplay=autoplay, maxwidth=maxwidth)
+
+    try:
+        thumbnail, media_object, secure_media_object = scraper.scrape()
+    except (HTTPError, URLError):
+        g.log.info("Unable to scrape suspected scrapable URL: %r", url)
+        return None
+
+    # No oembed? We don't want it for liveupdate.
+    if not media_object or 'oembed' not in media_object:
+        return None
+
+    # Use our exact passed URL to ensure matching in markdown.
+    # Some scrapers will canonicalize a URL to something we
+    # haven't seen yet.
+    media_object['oembed']['url'] = url
+
+    return media_object
+
+
+class LiveScraper(Scraper):
+    """The interface to Scraper to be used within liveupdate for media embeds.
+
+    Has support for scrapers that we don't necessarily want to be visible in
+    reddit core (like twitter, for example). Outside of the hook system
+    so that this functionality is not live for all uses of Scraper proper.
+
+    """
+
+    @classmethod
+    def for_url(cls, url, autoplay=False, maxwidth=485):
+        if (_TwitterScraper.matches(url)):
+            return _TwitterScraper(url)
+
+        return super(LiveScraper, cls).for_url(url,
+                                               autoplay=autoplay,
+                                               maxwidth=maxwidth)
+
+
+class _TwitterScraper(Scraper):
+    OEMBED_ENDPOINT = "https://api.twitter.com/1/statuses/oembed.json"
+    URL_MATCH = re.compile(r"""https?:
+                               //(www\.)?twitter\.com
+                               /\w{1,20}
+                               /status(es)?
+                               /\d+
+                            """, re.X)
+
+    def __init__(self, url, maxwidth=485, omit_script=False):
+        self.url = url
+        self.maxwidth = maxwidth
+        self.omit_script = False
+
+    @classmethod
+    def matches(cls, url):
+        return cls.URL_MATCH.match(url)
+
+    def _fetch_from_twitter(self):
+        params = {
+            "url": self.url,
+            "format": "json",
+            "maxwidth": self.maxwidth,
+            "omit_script": self.omit_script,
+        }
+
+        content = requests.get(self.OEMBED_ENDPOINT, params=params).content
+        return json.loads(content)
+
+    def _make_media_object(self, oembed):
+        if oembed.get("type") in ("video", "rich"):
+            return {
+                "type": "twitter.com",
+                "oembed": oembed,
+            }
+        return None
+
+    def scrape(self):
+        oembed = self._fetch_from_twitter()
+        if not oembed:
+            return None, None, None
+
+        media_object = self._make_media_object(oembed)
+
+        return (
+            None,  # no thumbnails for twitter
+            media_object,
+            media_object,  # Twitter's response is ssl ready by default
+        )
+
+    @classmethod
+    def media_embed(cls, media_object):
+        oembed = media_object["oembed"]
+
+        html = oembed.get("html")
+        width = oembed.get("width")
+
+        # Right now Twitter returns no height, so we get ''.
+        # We'll reset the height with JS dynamically, but if they support
+        # height in the future, this should work transparently.
+        height = oembed.get("height") or 0
+
+        if not html and width:
+            return
+
+        return MediaEmbed(
+            width=width,
+            height=height,
+            content=html,
+        )
+
+
+def process_liveupdate_scraper_q():
+    @g.stats.amqp_processor('liveupdate_scraper_q')
+    def _handle_q(msg):
+        d = json.loads(msg.body)
+        liveupdate = parse_embeds(d['event_id'], d['liveupdate_id'])
+
+        if not liveupdate.media_objects:
+            return
+
+        payload = {
+            "liveupdate_id": d['liveupdate_id'],
+            "media_embeds": liveupdate.embeds
+        }
+        send_event_broadcast(d['event_id'],
+                             type="embeds_ready",
+                             payload=payload)
+
+    amqp.consume_items('liveupdate_scraper_q', _handle_q, verbose=False)

--- a/reddit_liveupdate/models.py
+++ b/reddit_liveupdate/models.py
@@ -8,8 +8,9 @@ import pytz
 from pycassa.util import convert_uuid_to_time
 from pycassa.system_manager import TIME_UUID_TYPE, UTF8_TYPE
 
-from r2.lib.db import tdb_cassandra
 from r2.lib import utils
+from r2.lib.db import tdb_cassandra
+
 
 from reddit_liveupdate.permissions import ReporterPermissionSet
 
@@ -122,6 +123,7 @@ class LiveUpdate(object):
     defaults = {
         "deleted": False,
         "stricken": False,
+        "media_objects": [],
     }
 
     def __init__(self, id=None, data=None):
@@ -160,6 +162,19 @@ class LiveUpdate(object):
     @property
     def _fullname(self):
         return "%s_%s" % (self.__class__.__name__, self._id)
+
+    @property
+    def embeds(self):
+        """Return the media objects in a whitelisted, json-ready format."""
+
+        embeds = []
+        for media_object in self.media_objects:
+            embeds.append({
+                "url": media_object['oembed']['url'],
+                "width": media_object['oembed']['width'],
+                "height": media_object['oembed']['height'],
+            })
+        return embeds
 
 
 class ActiveVisitorsByLiveUpdateEvent(tdb_cassandra.View):

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -8,7 +8,12 @@ from pylons import c, g
 from pylons.i18n import _, ungettext
 
 from r2.lib import filters
-from r2.lib.pages import Reddit, UserTableItem, ModeratorPermissions
+from r2.lib.pages import (
+    Reddit,
+    UserTableItem,
+    MediaEmbedBody,
+    ModeratorPermissions,
+)
 from r2.lib.menus import NavMenu, NavButton
 from r2.lib.template_helpers import add_sr
 from r2.lib.memoize import memoize
@@ -37,10 +42,12 @@ class LiveUpdatePage(Reddit):
     extra_stylesheets = Reddit.extra_stylesheets + ["liveupdate.less"]
 
     def __init__(self, content, websocket_url=None):
+
         extra_js_config = {
             "liveupdate_event": c.liveupdate_event._id,
             "liveupdate_pixel_domain": g.liveupdate_pixel_domain,
             "liveupdate_permissions": c.liveupdate_permissions,
+            "media_domain": g.media_domain,
         }
 
         if websocket_url:
@@ -319,6 +326,10 @@ class LiveUpdateListing(Listing):
             items.append(update)
 
         return items
+
+
+class LiveUpdateMediaEmbedBody(MediaEmbedBody):
+    pass
 
 
 def liveupdate_add_props(user, wrapped):

--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -137,7 +137,7 @@ body.embed .infobar.welcome {
                 word-break: break-word;
             }
 
-            form, p {
+            form {
                 display: inline;
             }
 
@@ -226,6 +226,10 @@ body.embed .infobar.welcome {
             }
         }
     }
+}
+
+.embedFrame {
+    border: 0;
 }
 
 #noresults {

--- a/reddit_liveupdate/public/static/js/scrollupdater.js
+++ b/reddit_liveupdate/public/static/js/scrollupdater.js
@@ -1,0 +1,115 @@
+r.ScrollUpdater = Backbone.View.extend({
+    selector: null,
+    update: function() {},
+
+    start: function() {
+        this._resetScrollState()
+        this._listen()
+        return this
+    },
+
+    restart: function() {
+        this._resetScrollState()
+        return this
+    },
+
+    _resetScrollState: function() {
+        this._elements = $(this.selector)
+        _.sortBy(this._elements, function(el) {
+            return $(el).offset().top
+        })
+
+        this._curIndex = 0
+        this._lastScroll = null
+        this._toUpdate = []
+        this._totalTime = 0
+
+        // Trigger once now to detect any elements currently in view.
+        _.defer($.proxy(this, '_updateThings'))
+    },
+
+    _listen: function() {
+        var throttledUpdate = _.throttle($.proxy(this, '_updateThings'), 20)
+        $(window).on("scroll", throttledUpdate)
+    },
+
+    _updateThings: function(ev) {
+        if (!this._elements.length) {
+            return
+        }
+
+        var startTime = new Date()
+
+        // update the current page of elements and half a page in the
+        // direction of motion
+        var $win = $(window),
+            winHeight = $win.height(),
+            scrollTop = $win.scrollTop(),
+            ceiling = scrollTop,
+            floor = scrollTop + winHeight
+
+        if (scrollTop < this._lastScroll) {
+            ceiling = Math.max(ceiling - Math.floor(winHeight / 2), 0)
+        } else {
+            floor += Math.ceil(winHeight / 2)
+        }
+
+        // scan to ceiling to set the cursor
+        var idx = this._curIndex,
+            $cur = $(this._elements[idx])
+        if ($cur.offset().top < ceiling) {
+            // forward
+            while (idx < this._elements.length-1 && $cur.offset().top < ceiling) {
+                $cur = $(this._elements[idx])
+                idx++
+            }
+        } else {
+            // backward
+            while (idx > 0 && $cur.offset().top > ceiling) {
+                $cur = $(this._elements[idx])
+                idx--
+            }
+        }
+
+        // update forward to floor
+        var count = 0
+        do {
+            $cur = $(this._elements[idx])
+            this._toUpdate.push($cur)
+            idx++
+            count++
+        } while (idx <= this._elements.length-1 && $cur.offset().top <= floor)
+
+        this._curIndex = idx - 1
+        this._lastScroll = scrollTop
+
+        var endTime = new Date()
+        this._totalTime += endTime - startTime
+
+        r.debug('scrollupdater queued', count, 'in', endTime - startTime, 'ms')
+
+        this._doUpdates()
+    },
+
+    cutoff: 1000 / 60,
+    _doUpdates: function() {
+        var startTime = new Date(),
+            endTime = startTime,
+            count = 0
+        while (endTime - startTime < this.cutoff) {
+            if (!this._toUpdate.length) {
+                break
+            }
+            var $el = this._toUpdate.shift()
+            this.update($el)
+            count++
+            endTime = new Date()
+        }
+        this._totalTime += endTime - startTime
+        r.debug('scrollupdater updated', count, 'in', endTime - startTime, 'ms')
+        r.debug('scrollupdater total', this._totalTime, 'ms')
+        if (this._toUpdate.length) {
+            _.defer($.proxy(this, '_doUpdates'))
+        }
+    }
+})

--- a/reddit_liveupdate/templates/liveupdate.html
+++ b/reddit_liveupdate/templates/liveupdate.html
@@ -1,5 +1,6 @@
 <%!
 
+  import json
   from r2.lib.template_helpers import html_datetime
   from babel.dates import format_datetime
 
@@ -8,7 +9,7 @@
 <%namespace file="utils.html" name="utils" />
 <%namespace file="printablebuttons.html" import="ynbutton" />
 
-<tr data-fullname="${thing._fullname}" class="thing id-${thing._fullname} ${"stricken" if thing.stricken else ""}">
+<tr data-fullname="${thing._fullname}" data-embeds="${json.dumps(thing.embeds)}" class="thing id-${thing._fullname} ${"stricken" if thing.stricken else ""} ${"pending-embed" if thing.embeds else ""}">
   <th scope="row">
     <time title="${format_datetime(thing._date, format='long', tzinfo=c.liveupdate_event.timezone, locale=c.locale)}" datetime="${html_datetime(thing._date)}" class="live">${thing.date_str}</time>
   </th>

--- a/reddit_liveupdate/templates/liveupdatemediaembedbody.html
+++ b/reddit_liveupdate/templates/liveupdatemediaembedbody.html
@@ -1,0 +1,43 @@
+<%!
+   import json
+%>
+<!doctype html>
+<html>
+<head>
+    <style type="text/css">
+    html, iframe, body, object, embed, div, span, p {
+        margin: 0;
+        padding: 0;
+    }
+    </style>
+</head>
+<body>
+    ${unsafe(thing.body)}
+    % if thing.unknown_dimensions:
+    <script type="text/javascript">
+    if (window.parent) {
+        var knownWidth = 0, knownHeight = 0;
+        window.setInterval(function() {
+            var root = document.documentElement,
+                context = ${unsafe(json.dumps(thing.js_context))};
+
+            if (knownWidth === root.offsetWidth && knownHeight === root.offsetHeight) {
+                return;
+            }
+
+            knownWidth = root.offsetWidth;
+            knownHeight = root.offsetHeight;
+
+            window.parent.postMessage(JSON.stringify({
+                "action": "dimensionsChange",
+                "width": knownWidth,
+                "height": knownHeight,
+                "updateId": context.liveupdate_id,
+                "embedIndex": context.embed_index
+            }), '*');
+        }, 500);
+    }
+    </script>
+    % endif
+</body>
+</html>

--- a/reddit_liveupdate/utils.py
+++ b/reddit_liveupdate/utils.py
@@ -5,6 +5,7 @@ import pytz
 
 from babel.dates import format_time, format_datetime
 from pylons import c
+from r2.lib import websockets
 
 
 def pairwise(iterable):
@@ -39,3 +40,10 @@ def pretty_time(dt):
             format="dd MMM YYYY HH:mm z",
             locale=c.locale,
         )
+
+
+def send_event_broadcast(event_id, type, payload):
+    """ Send a liveupdate broadcast for a specific event. """
+    websockets.send_broadcast(namespace="/live/" + event_id,
+                              type=type,
+                              payload=payload)

--- a/upstart/reddit-consumer-liveupdate_q.conf
+++ b/upstart/reddit-consumer-liveupdate_q.conf
@@ -1,0 +1,15 @@
+description "consume async events from the liveupdate_scraper_q"
+
+instance $x
+
+stop on reddit-stop or runlevel [016]
+
+respawn
+respawn limit 10 5
+
+nice 10
+script
+    . /etc/default/reddit
+    wrap-job paster run --proctitle liveupdate_scraper_q$x $REDDIT_INI -c 'from reddit_liveupdate.media_embeds import process_liveupdate_scraper_q; process_liveupdate_scraper_q()'
+end script
+


### PR DESCRIPTION
:eyeglasses: @spladug @chromakode

Hello hello and welcome to another episode of liveupdate media embeds!

This takes into account feedback from the previous PR and has a good deal of improvements. Primarily:
- `MediaByURL` is now used to fetch cached embeds across updates.
- Embedding/scraping logic has been gathered into one module, `media_embeds`
- Embeds are only rendered if the URL is on its own line (and additionally updates now render as block.)
- `liveupdate_q` has been clarified as the `liveupdate_scraper_q`

Still "outstanding": We haven't solved the redditmedia herd problem, but I'm wondering if we should cross that bridge when we get to it. It's a sticky problem, and since it's under redditmedia, that would mean it's going to be served through our CDN infrastructure anyhow, right? There's additionally a bit of kludginess when it comes to the MediaByURL caching, as you'll see inline. I'd be happy to volunteer to clean that up down the line, but I don't think it should block us from this work.

Thoughts appreciated, thanks for feedback on the previous PR. Keep in mind that you'll need this pull request to allow differing widths to be in your working copy of core if you want to test.
