### PR TITLE
Add mutation observing, max-widths for embeds dimensions

### DIFF
--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -230,6 +230,7 @@ body.embed .infobar.welcome {
 
 .embedFrame {
     border: 0;
+    max-width: 100%;
 }
 
 #noresults {

--- a/reddit_liveupdate/templates/liveupdatemediaembedbody.html
+++ b/reddit_liveupdate/templates/liveupdatemediaembedbody.html
@@ -9,25 +9,30 @@
         margin: 0;
         padding: 0;
     }
+
+    iframe {
+        max-width: 100%;
+    }
     </style>
 </head>
 <body>
     ${unsafe(thing.body)}
+
     % if thing.unknown_dimensions:
     <script type="text/javascript">
     if (window.parent) {
-        var knownWidth = 0, knownHeight = 0;
-        window.setInterval(function() {
-            var root = document.documentElement,
-                context = ${unsafe(json.dumps(thing.js_context))};
+        var root = document.documentElement,
+            context = ${unsafe(json.dumps(thing.js_context))},
+            knownHeight = 0,
+            knownWidth = 0;
 
-            if (knownWidth === root.offsetWidth && knownHeight === root.offsetHeight) {
+        var checkDimensions = function() {
+            if (root.offsetHeight === knownHeight && root.offsetWidth === knownWidth) {
                 return;
             }
 
             knownWidth = root.offsetWidth;
             knownHeight = root.offsetHeight;
-
             window.parent.postMessage(JSON.stringify({
                 "action": "dimensionsChange",
                 "width": knownWidth,
@@ -35,7 +40,17 @@
                 "updateId": context.liveupdate_id,
                 "embedIndex": context.embed_index
             }), '*');
-        }, 500);
+        };
+
+        if ('MutationObserver' in window) {
+            /* Currently just check on every set of mutations. */
+            var observer = new MutationObserver(checkDimensions),
+                config = { attributes: true, subtree: true};
+
+            observer.observe(root, config);
+        } else {
+            window.setInterval(checkDimensions, 500);
+        }
     }
     </script>
     % endif


### PR DESCRIPTION
:eyeglasses: @spladug @chromakode
1. Don't poll in browsers that support [Mutation Observers](http://caniuse.com/mutationobserver). For those that don't, poll.
2. A little fix to max-widths to make embeds friendly to small screens.
