### PR TITLE
Update timetext elCache when receiving new updates on socket.

### DIFF
--- a/reddit_liveupdate/public/static/js/liveupdate.js
+++ b/reddit_liveupdate/public/static/js/liveupdate.js
@@ -116,8 +116,9 @@ r.liveupdate = {
 
         var $newThing = $($.unsafe(thing.rendered))
         this.$listing.trigger('more-updates', [$newThing])
-        $initial.after($newThing)
         this.timeText.refreshOne($newThing.find('.live-timestamp'))
+        $initial.after($newThing)
+        this.timeText.updateCache($('.live-timestamp'))
 
         if (!this._pageVisible) {
             this._unreadUpdates += 1


### PR DESCRIPTION
New updates coming in on the websocket aren't getting picked up by timetext (since the element cache is not being updated) so they stay "just now" forever.

:eyeglasses: @chromakode @ajacksified 
