### PR TITLE
Make p and form tags in liveupdate updates display block.

### DIFF
--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -182,7 +182,7 @@ body.liveupdate-event{
                     padding-bottom: 1em;
                 }
 
-                form, p {
+                form, p:last-of-type {
                     display: inline;
                 }
 


### PR DESCRIPTION
:eyeglasses: @powerlanguage @chromakode @spladug

I removed this once before but it looks like it snuck back in with the redesign.

For many updates that are > a paragraph long we need to be able to break. This is a quasi-urgent need requested by Mike. 

With this change the opening text for the Maker's Mark thread for example will look like:

![image](https://cloud.githubusercontent.com/assets/285920/2857280/cbc5c8a6-d175-11e3-886d-26b99acca6d4.png)

Without it it looks like:

![image](https://cloud.githubusercontent.com/assets/285920/2857283/d7b1f0ea-d175-11e3-9eff-178fe1fd3e02.png)
