### PR TITLE
Rename "reporters" to "contributors".

### DIFF
--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -9,7 +9,7 @@ from r2.lib.js import (
 )
 from r2.lib.plugin import Plugin
 
-from reddit_liveupdate.permissions import ReporterPermissionSet
+from reddit_liveupdate.permissions import ContributorPermissionSet
 
 
 class LiveUpdate(Plugin):
@@ -31,11 +31,11 @@ class LiveUpdate(Plugin):
             "scrollupdater.js",
             "liveupdate.js",
         ),
-        "liveupdate-reporter": LocalizedModule("liveupdate-reporter.js",
-            "liveupdate-reporter.js",
+        "liveupdate-contributor": LocalizedModule("liveupdate-contributor.js",
+            "liveupdate-contributor.js",
             TemplateFileSource("liveupdate/edit-buttons.html"),
             PermissionsDataSource({
-                "liveupdate_reporter": ReporterPermissionSet,
+                "liveupdate_contributor": ContributorPermissionSet,
             }),
         ),
     }

--- a/reddit_liveupdate/models.py
+++ b/reddit_liveupdate/models.py
@@ -12,11 +12,11 @@ from r2.lib import utils
 from r2.lib.db import tdb_cassandra
 
 
-from reddit_liveupdate.permissions import ReporterPermissionSet
+from reddit_liveupdate.permissions import ContributorPermissionSet
 
 
 class LiveUpdateEvent(tdb_cassandra.Thing):
-    _reporter_prefix = "reporter_"
+    _contributor_prefix = "contributor_"
 
     _use_db = True
     _read_consistency_level = tdb_cassandra.CL.ONE
@@ -34,34 +34,34 @@ class LiveUpdateEvent(tdb_cassandra.Thing):
     }
 
     @classmethod
-    def _reporter_key(cls, user):
-        return "%s%s" % (cls._reporter_prefix, user._id36)
+    def _contributor_key(cls, user):
+        return "%s%s" % (cls._contributor_prefix, user._id36)
 
-    def add_reporter(self, user, permissions):
-        self[self._reporter_key(user)] = permissions.dumps()
+    def add_contributor(self, user, permissions):
+        self[self._contributor_key(user)] = permissions.dumps()
         self._commit()
 
-    def update_reporter_permissions(self, user, permissions):
-        return self.add_reporter(user, permissions)
+    def update_contributor_permissions(self, user, permissions):
+        return self.add_contributor(user, permissions)
 
-    def remove_reporter(self, user):
-        del self[self._reporter_key(user)]
+    def remove_contributor(self, user):
+        del self[self._contributor_key(user)]
         self._commit()
 
     def get_permissions(self, user):
-        permission_string = self._t.get(self._reporter_key(user), "")
-        return ReporterPermissionSet.loads(permission_string)
+        permission_string = self._t.get(self._contributor_key(user), "")
+        return ContributorPermissionSet.loads(permission_string)
 
     @property
     def _fullname(self):
         return self._id
 
     @property
-    def reporters(self):
-        return {int(k[len(self._reporter_prefix):], 36):
-                    ReporterPermissionSet.loads(v)
+    def contributors(self):
+        return {int(k[len(self._contributor_prefix):], 36):
+                    ContributorPermissionSet.loads(v)
                 for k, v in self._t.iteritems()
-                if k.startswith(self._reporter_prefix)}
+                if k.startswith(self._contributor_prefix)}
 
     @classmethod
     def new(cls, id, title, **properties):

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -28,7 +28,7 @@ from r2.lib.jsontemplates import (
 )
 
 from reddit_liveupdate.activity import ACTIVITY_FUZZING_THRESHOLD
-from reddit_liveupdate.permissions import ReporterPermissionSet
+from reddit_liveupdate.permissions import ContributorPermissionSet
 from reddit_liveupdate.utils import pretty_time, pairwise
 
 
@@ -79,8 +79,8 @@ class LiveUpdatePage(Reddit):
 
             if c.liveupdate_permissions.allow("manage"):
                 tabs.append(NavButton(
-                    _("reporters"),
-                    "/reporters",
+                    _("contributors"),
+                    "/contributors",
                 ))
 
             toolbars.append(NavMenu(
@@ -105,11 +105,11 @@ class LiveUpdateEvent(Templated):
             self.discussions = LiveUpdateOtherDiscussions()
         self.show_sidebar = show_sidebar
 
-        reporter_accounts = Account._byID(event.reporters.keys(),
-                                          data=True, return_dict=False)
-        self.reporters = sorted((LiveUpdateAccount(e)
-                                 for e in reporter_accounts),
-                                key=lambda e: e.name)
+        contributor_accounts = Account._byID(event.contributors.keys(),
+                                             data=True, return_dict=False)
+        self.contributors = sorted((LiveUpdateAccount(e)
+                                   for e in contributor_accounts),
+                                   key=lambda e: e.name)
 
         Templated.__init__(self)
 
@@ -136,27 +136,27 @@ class LiveUpdateEventConfiguration(Templated):
         Templated.__init__(self)
 
 
-class LiveUpdateReporterPermissions(ModeratorPermissions):
+class LiveUpdateContributorPermissions(ModeratorPermissions):
     def __init__(self, account, permissions, embedded=False):
         ModeratorPermissions.__init__(
             self,
             user=account,
-            permissions_type=ReporterTableItem.type,
+            permissions_type=ContributorTableItem.type,
             permissions=permissions,
             editable=True,
             embedded=embedded,
         )
 
 
-class ReporterTableItem(UserTableItem):
-    type = "liveupdate_reporter"
+class ContributorTableItem(UserTableItem):
+    type = "liveupdate_contributor"
 
-    def __init__(self, reporter, event, editable):
+    def __init__(self, contributor, event, editable):
         self.event = event
-        self.render_class = ReporterTableItem
-        self.permissions = LiveUpdateReporterPermissions(
-            reporter.account, reporter.permissions)
-        UserTableItem.__init__(self, reporter.account, editable=editable)
+        self.render_class = ContributorTableItem
+        self.permissions = LiveUpdateContributorPermissions(
+            contributor.account, contributor.permissions)
+        UserTableItem.__init__(self, contributor.account, editable=editable)
 
     @property
     def cells(self):
@@ -180,14 +180,14 @@ class ReporterTableItem(UserTableItem):
 
     @property
     def remove_action(self):
-        return "live/%s/rm_reporter" % self.event._id
+        return "live/%s/rm_contributor" % self.event._id
 
 
-class ReporterListing(UserListing):
-    type = "liveupdate_reporter"
-    permissions_form = LiveUpdateReporterPermissions(
+class ContributorListing(UserListing):
+    type = "liveupdate_contributor"
+    permissions_form = LiveUpdateContributorPermissions(
         account=None,
-        permissions=ReporterPermissionSet.SUPERUSER,
+        permissions=ContributorPermissionSet.SUPERUSER,
         embedded=True,
     )
 
@@ -197,15 +197,15 @@ class ReporterListing(UserListing):
 
     @property
     def destination(self):
-        return "live/%s/add_reporter" % self.event._id
+        return "live/%s/add_contributor" % self.event._id
 
     @property
     def form_title(self):
-        return _("add reporter")
+        return _("add contributor")
 
     @property
     def title(self):
-        return _("current reporters")
+        return _("current contributors")
 
     @property
     def container_name(self):

--- a/reddit_liveupdate/permissions.py
+++ b/reddit_liveupdate/permissions.py
@@ -3,7 +3,7 @@ from pylons.i18n import N_
 from r2.lib.permissions import PermissionSet
 
 
-class ReporterPermissionSet(PermissionSet):
+class ContributorPermissionSet(PermissionSet):
     info = {
         "update": {
             "title": N_("update"),
@@ -11,8 +11,8 @@ class ReporterPermissionSet(PermissionSet):
         },
 
         "manage": {
-            "title": N_("manage reporters"),
-            "description": N_("add, remove, and change permissions of reporters"),
+            "title": N_("manage contributors"),
+            "description": N_("add, remove, and change permissions of contributors"),
         },
 
         "settings": {
@@ -38,8 +38,8 @@ class ReporterPermissionSet(PermissionSet):
             permissions = self.copy()
 
         permissions.pop(permission, None)
-        return ReporterPermissionSet(permissions)
+        return ContributorPermissionSet(permissions)
 
 
-ReporterPermissionSet.SUPERUSER = ReporterPermissionSet.loads("+all")
-ReporterPermissionSet.NONE = ReporterPermissionSet.loads("")
+ContributorPermissionSet.SUPERUSER = ContributorPermissionSet.loads("+all")
+ContributorPermissionSet.NONE = ContributorPermissionSet.loads("")

--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -475,7 +475,7 @@ body.liveupdate-event{
                 }
             }
 
-            #reporters {
+            #contributors {
 
                 li {
                     display: inline;
@@ -551,7 +551,7 @@ body.liveupdate-event{
         }
     }
 
-    // settings and reporters page
+    // settings and contributors page
 
     #liveupdate-form .linefield {
         -webkit-box-sizing: border-box;
@@ -576,7 +576,7 @@ body.liveupdate-event{
         }
     }
 
-    #liveupdate_reporter input#name {
+    #liveupdate_contributor input#name {
         width: 50%;
     }
 

--- a/reddit_liveupdate/public/static/js/liveupdate-contributor.js
+++ b/reddit_liveupdate/public/static/js/liveupdate-contributor.js
@@ -1,4 +1,4 @@
-r.liveupdate.reporter = {
+r.liveupdate.contributor = {
     init: function () {
         this.permissions = new r.liveupdate.PermissionSet(r.config.liveupdate_permissions)
         this.$listing = $('.liveupdate-listing')
@@ -101,4 +101,4 @@ r.liveupdate.PermissionSet.prototype = {
     }
 }
 
-$(function () { r.liveupdate.reporter.init() })
+$(function () { r.liveupdate.contributor.init() })

--- a/reddit_liveupdate/templates/liveupdatecontributorpermissions.html
+++ b/reddit_liveupdate/templates/liveupdatecontributorpermissions.html
@@ -24,7 +24,7 @@
     ${form_content()}
   %else:
     <form method="post" class="pretty-form medium-text"
-      onsubmit="return post_form(this, 'live/${c.liveupdate_event._id}/set_reporter_permissions')">
+      onsubmit="return post_form(this, 'live/${c.liveupdate_event._id}/set_contributor_permissions')">
       ${form_content()}
       <button type="submit">${_('save')}</button>
     </form>

--- a/reddit_liveupdate/templates/liveupdateevent.html
+++ b/reddit_liveupdate/templates/liveupdateevent.html
@@ -1,7 +1,7 @@
 <%!
   from r2.lib.pages import UserText
 
-  REPORTER_CUTOFF = 3
+  CONTRIBUTOR_CUTOFF = 3
 %>
 
 <%namespace name="utils" file="utils.html" />
@@ -45,17 +45,17 @@
     <h1>${_("discussions")}</h1>
     ${thing.discussions}
   </section>
-  <section id="reporters">
-    <h1>${_("reported by")}</h1>
+  <section id="contributors">
+    <h1>${_("updated by")}</h1>
 
     <ul>
-      % for reporter in thing.reporters[:REPORTER_CUTOFF]:
-      <li>${reporter}</li>
+      % for contributor in thing.contributors[:CONTRIBUTOR_CUTOFF]:
+      <li>${contributor}</li>
       % endfor
     </ul>
 
-    % if len(thing.reporters) > REPORTER_CUTOFF:
-    <a href="/live/${c.liveupdate_event._id}/reporters" class="more-reporters">${unsafe(_("&hellip; and %(count)s more &raquo;") % dict(count=len(thing.reporters) - REPORTER_CUTOFF))}</a>
+    % if len(thing.contributors) > CONTRIBUTOR_CUTOFF:
+    <a href="/live/${c.liveupdate_event._id}/contributors" class="more-contributors">${unsafe(_("&hellip; and %(count)s more &raquo;") % dict(count=len(thing.contributors) - CONTRIBUTOR_CUTOFF))}</a>
     % endif
   </section>
 

--- a/reddit_liveupdate/templates/liveupdatepage.html
+++ b/reddit_liveupdate/templates/liveupdatepage.html
@@ -11,6 +11,6 @@
     ${unsafe(js.use("liveupdate"))}
 
     % if c.liveupdate_permissions:
-    ${unsafe(js.use("liveupdate-reporter"))}
+    ${unsafe(js.use("liveupdate-contributor"))}
     % endif
 </%def>

--- a/reddit_liveupdate/validators.py
+++ b/reddit_liveupdate/validators.py
@@ -10,7 +10,7 @@ from r2.lib.db import tdb_cassandra
 from r2.lib.errors import errors
 
 from reddit_liveupdate import models
-from reddit_liveupdate.permissions import ReporterPermissionSet
+from reddit_liveupdate.permissions import ContributorPermissionSet
 
 
 class VLiveUpdateID(Validator):
@@ -40,7 +40,7 @@ class VLiveUpdate(VLiveUpdateID):
         self.set_error(errors.NO_THING_ID)
 
 
-class VLiveUpdateReporterWithPermission(Validator):
+class VLiveUpdateContributorWithPermission(Validator):
     def __init__(self, permission):
         self.permission = permission
         Validator.__init__(self)
@@ -60,5 +60,5 @@ class VTimeZone(Validator):
 
 class VLiveUpdatePermissions(VPermissions):
     types = {
-        "liveupdate_reporter": ReporterPermissionSet,
+        "liveupdate_contributor": ContributorPermissionSet,
     }


### PR DESCRIPTION
The more generic term allows for mixes of professional and amateur
contributors in the same event without legal confusion. It also covers
more cases since for game events it's more like "announcer" or
"commentator" etc.

The term only really shows up in the behind-the-scenes stuff
(contributor-only pages and in the code) and the sidebar now says
"updated by".

Migration will be handled the exact same manual way I did for
the rename from "editor" to "reporter".

:eyeglasses: @chromakode @umbrae 
