### PR TITLE
Add some missing fields to the JSON for updates.

### DIFF
--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -226,6 +226,9 @@ class LiveUpdateJsonTemplate(ThingJsonTemplate):
         id="_id",
         body="body",
         body_html="body_html",
+        author="author",
+        stricken="stricken",
+        embeds="embeds",
     )
 
     def thing_attr(self, thing, attr):
@@ -233,6 +236,13 @@ class LiveUpdateJsonTemplate(ThingJsonTemplate):
             return str(thing._id)
         elif attr == "body_html":
             return filters.spaceCompress(filters.safemarkdown(thing.body))
+        elif attr == "author":
+            if not thing.author.deleted:
+                return thing.author.name
+            else:
+                return None
+        elif attr == "stricken":
+            return bool(thing.stricken)
         return ThingJsonTemplate.thing_attr(self, thing, attr)
 
     def kind(self, wrapped):


### PR DESCRIPTION
The missing fields were:

```
* author
* stricken
* embeds
```

These were being added as part of my backbonification, but this'll make it so some extensions in the wild can cut over to the JSON rather than scraping HTML before I drastically re-do the HTML in the backbone branch.

:eyeglasses: @umbrae @chromakode 
