### PR TITLE
Update dimension checking selector now that .id- based selection is gone.

### DIFF
--- a/reddit_liveupdate/public/static/js/liveupdate/embeds.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/embeds.js
@@ -43,7 +43,8 @@
         var $link = $el.find('a[href="' + embed.url + '"]')
         var embedUri = this._embedBase + '/' + updateId + '/' + embedIndex
         var iframe = $('<iframe>').attr({
-          'class': 'embedFrame embed-' + embedIndex,
+          'class': 'embedFrame',
+          'id': 'embed-' + updateId + '-' + embedIndex,
           'src': embedUri,
           'width': embed.width,
           'height': embed.height || 200,
@@ -66,8 +67,7 @@
       var $embedFrame
 
       if (data.action === 'dimensionsChange') {
-        // Yuck. A good reason to give embeds unique IDs.
-        $('.id-LiveUpdate_' + data.updateId + ' .embed-' + data.embedIndex)
+        $('#embed-LiveUpdate_' + data.updateId + '-' + data.embedIndex)
           .attr({
             'width': Math.min(data.width, 480),
             'height': data.height,


### PR DESCRIPTION
:eyeglasses: @spladug

It looks like .id-\* classnames are [still being populated in liveupdate.html](https://github.com/reddit/reddit-plugin-liveupdate/blob/master/reddit_liveupdate/templates/liveupdate.html#L12) but are [not being populated by backbone](https://github.com/reddit/reddit-plugin-liveupdate/blob/master/reddit_liveupdate/public/static/js/liveupdate/listings.js#L161), leading to backbone-populated updates not receiving dimensions changes.

This fixes that. It looks like .id-\* classNames aren't being relied upon at all anymore (yay) except in `onReset`, which I can't seem to trigger, but it may be out of lack of experience with backbone. We may be able to remove that from the template entirely. If we can't, we probably will want to add .id-\* classNames into backbone's render.
