### PR TITLE
Use local timezone, allow users to close events, and a bonus bugfix.

### DIFF
--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -1,7 +1,5 @@
 import sys
 
-from pylons.i18n import N_
-
 from r2.config.routing import not_in_sr
 from r2.lib.configparse import ConfigValue
 from r2.lib.js import (
@@ -63,10 +61,6 @@ class LiveUpdate(Plugin):
                 MomentTranslations(),
             ],
         ),
-    }
-
-    errors = {
-        "INVALID_TIMEZONE": N_("that is not a valid timezone"),
     }
 
     def add_routes(self, mc):

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -441,7 +441,7 @@ class LiveUpdateController(RedditController):
         VLiveUpdateContributorWithPermission("close"),
         VModhash(),
     )
-    def POST_complete_stream(self, form, jquery):
+    def POST_close_stream(self, form, jquery):
         c.liveupdate_event.state = "complete"
         c.liveupdate_event._commit()
 

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -169,10 +169,12 @@ class LiveUpdateController(RedditController):
             c.liveupdate_permissions = \
                     c.liveupdate_event.get_permissions(c.user)
 
-            # revoke "update" permission from everyone after closing
+            # revoke some permissions from everyone after closing
             if c.liveupdate_event.state != "live":
-                c.liveupdate_permissions = \
-                        c.liveupdate_permissions.without("update")
+                c.liveupdate_permissions = (c.liveupdate_permissions
+                    .without("update")
+                    .without("close")
+                )
 
             if c.user_is_admin:
                 c.liveupdate_permissions = ContributorPermissionSet.SUPERUSER
@@ -434,6 +436,18 @@ class LiveUpdateController(RedditController):
         LiveUpdateStream.add_update(c.liveupdate_event, update)
 
         _broadcast(type="strike", payload=update._fullname)
+
+    @validatedForm(
+        VLiveUpdateContributorWithPermission("close"),
+        VModhash(),
+    )
+    def POST_complete_stream(self, form, jquery):
+        c.liveupdate_event.state = "complete"
+        c.liveupdate_event._commit()
+
+        _broadcast(type="complete", payload={})
+
+        form.refresh()
 
 
 @add_controller

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -51,7 +51,6 @@ from reddit_liveupdate.validators import (
     VLiveUpdateContributorWithPermission,
     VLiveUpdatePermissions,
     VLiveUpdateID,
-    VTimeZone,
 )
 
 
@@ -276,17 +275,13 @@ class LiveUpdateController(RedditController):
         VModhash(),
         title=VLength("title", max_length=120),
         description=VMarkdown("description", empty_error=None),
-        timezone=VTimeZone("timezone"),
     )
-    def POST_edit(self, form, jquery, title, description, timezone):
+    def POST_edit(self, form, jquery, title, description):
         if form.has_errors("title", errors.NO_TEXT,
                                     errors.TOO_LONG):
             return
 
         if form.has_errors("description", errors.TOO_LONG):
-            return
-
-        if form.has_errors("timezone", errors.INVALID_TIMEZONE):
             return
 
         changes = {}
@@ -299,7 +294,6 @@ class LiveUpdateController(RedditController):
 
         c.liveupdate_event.title = title
         c.liveupdate_event.description = description
-        c.liveupdate_event.timezone = timezone.zone
         c.liveupdate_event._commit()
 
         form.set_html(".status", _("saved"))

--- a/reddit_liveupdate/models.py
+++ b/reddit_liveupdate/models.py
@@ -30,7 +30,6 @@ class LiveUpdateEvent(tdb_cassandra.Thing):
     )
     _defaults = {
         "description": "",
-        "timezone": "UTC",
         # one of "live", "complete"
         "state": "live",
         "active_visitors": 0,

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -1,8 +1,4 @@
-import collections
-import datetime
 import urllib
-
-import pytz
 
 from pylons import c, g
 from pylons.i18n import _, ungettext
@@ -28,7 +24,7 @@ from r2.lib.jsontemplates import (
 )
 
 from reddit_liveupdate.permissions import ContributorPermissionSet
-from reddit_liveupdate.utils import pretty_time, pairwise
+from reddit_liveupdate.utils import pretty_time
 
 
 class LiveUpdatePage(Reddit):
@@ -36,15 +32,10 @@ class LiveUpdatePage(Reddit):
     extra_stylesheets = Reddit.extra_stylesheets + ["liveupdate.less"]
 
     def __init__(self, content, websocket_url=None, **kwargs):
-        timezone = pytz.timezone(c.liveupdate_event.timezone)
-        localized_now = datetime.datetime.now(pytz.UTC).astimezone(timezone)
-        utc_offset = localized_now.utcoffset()
-
         extra_js_config = {
             "liveupdate_event": c.liveupdate_event._id,
             "liveupdate_pixel_domain": g.liveupdate_pixel_domain,
             "liveupdate_permissions": c.liveupdate_permissions,
-            "liveupdate_utc_offset": utc_offset.total_seconds() // 60,
             "media_domain": g.media_domain,
         }
 
@@ -145,18 +136,7 @@ class LiveUpdateEventPage(Templated):
 
 
 class LiveUpdateEventConfiguration(Templated):
-    def __init__(self):
-        self.ungrouped_timezones = []
-        self.grouped_timezones = collections.defaultdict(list)
-
-        for tzname in pytz.common_timezones:
-            if "/" not in tzname:
-                self.ungrouped_timezones.append(tzname)
-            else:
-                region, zone = tzname.split("/", 1)
-                self.grouped_timezones[region].append(zone)
-
-        Templated.__init__(self)
+    pass
 
 
 class LiveUpdateContributorPermissions(ModeratorPermissions):
@@ -337,22 +317,8 @@ class LiveUpdateOtherDiscussions(Templated):
         return wrapped
 
 
-class LiveUpdateSeparator(Templated):
-    def __init__(self, older):
-        self.date = older.replace(minute=0, second=0, microsecond=0)
-        self.date_str = pretty_time(self.date, allow_relative=False)
-        Templated.__init__(self)
-
-
 class LiveUpdateListing(Listing):
-    def things_with_separators(self):
-        if self.things:
-            yield self.things[0]
-
-        for newer, older in pairwise(self.things):
-            if newer._date.hour != older._date.hour:
-                yield LiveUpdateSeparator(older._date)
-            yield older
+    pass
 
 
 class LiveUpdateMediaEmbedBody(MediaEmbedBody):

--- a/reddit_liveupdate/permissions.py
+++ b/reddit_liveupdate/permissions.py
@@ -24,6 +24,11 @@ class ContributorPermissionSet(PermissionSet):
             "title": N_("edit"),
             "description": N_("strike and delete others' updates"),
         },
+
+        "complete": {
+            "title": N_("complete {verb}"),
+            "description": N_("end the stream of updates"),
+        },
     }
 
     def allow(self, permission):

--- a/reddit_liveupdate/permissions.py
+++ b/reddit_liveupdate/permissions.py
@@ -25,9 +25,9 @@ class ContributorPermissionSet(PermissionSet):
             "description": N_("strike and delete others' updates"),
         },
 
-        "complete": {
-            "title": N_("complete {verb}"),
-            "description": N_("end the stream of updates"),
+        "close": {
+            "title": N_("close stream"),
+            "description": N_("permanently close the stream"),
         },
     }
 

--- a/reddit_liveupdate/permissions.py
+++ b/reddit_liveupdate/permissions.py
@@ -17,7 +17,7 @@ class ContributorPermissionSet(PermissionSet):
 
         "settings": {
             "title": N_("settings"),
-            "description": N_("change the title, description, and timezone"),
+            "description": N_("change the title and description"),
         },
 
         "edit": {

--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -582,3 +582,22 @@ body.liveupdate-event{
     float: left;
     background-image: url(../prev_organic.png);
 }
+
+.danger-zone {
+    margin-top: 2em;
+    background-color: #f8cece;
+
+    .title {
+        color: #800;
+    }
+
+    p {
+        padding-left: 3px;
+        font-size: 13px;
+    }
+
+    button {
+        margin-top: 1em;
+        color: #800;
+    }
+}

--- a/reddit_liveupdate/public/static/js/liveupdate/init.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/init.js
@@ -93,6 +93,11 @@
           model.set('embeds', data.media_embeds)
           this.embedViewer.restart()
         },
+        'message:complete': function() {
+          this.event.set('state', 'complete')
+          $options.remove()
+          $('#new-update-form').remove()
+        },
       }, this)
 
       if ('Notification' in window && !$('body').hasClass('embed')) {

--- a/reddit_liveupdate/public/static/js/liveupdate/init.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/init.js
@@ -22,7 +22,7 @@
 
   exports.LiveUpdateApp = function() {
     var $header = $('.content > header')
-    var $options
+    var $options = $('<div id="liveupdate-options">')
 
     this.permissions = new PermissionSet(r.config.liveupdate_permissions)
 
@@ -95,6 +95,17 @@
         },
       }, this)
 
+      if ('Notification' in window && !$('body').hasClass('embed')) {
+        this.desktopNotifier = new r.liveupdate.notifications.DesktopNotifier({
+          model: this.listing,
+        })
+        this.desktopNotifier.render()
+        $('<label>')
+          .text(r._('popup notifications'))
+          .prepend(this.desktopNotifier.$el)
+          .appendTo($options)
+      }
+
       this.websocket.start()
     }
 
@@ -103,17 +114,6 @@
       model: this.listing,
     })
 
-    $options = $('<div id="liveupdate-options">')
-    if ('Notification' in window && !$('body').hasClass('embed')) {
-      this.desktopNotifier = new r.liveupdate.notifications.DesktopNotifier({
-        model: this.listing,
-      })
-      this.desktopNotifier.render()
-      $('<label>')
-        .text(r._('popup notifications'))
-        .prepend(this.desktopNotifier.$el)
-        .appendTo($options)
-    }
     $options.insertAfter($header)
   }
 }(r, Backbone, jQuery, _)

--- a/reddit_liveupdate/public/static/js/liveupdate/listings.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/listings.js
@@ -285,7 +285,7 @@
       var $el
 
       if (olderDate.hour() !== newerDate.hour()) {
-        separatorDate = olderDate
+        separatorDate = newerDate
           .minutes(0)
           .seconds(0)
           .milliseconds(0)

--- a/reddit_liveupdate/public/static/js/liveupdate/update.html
+++ b/reddit_liveupdate/public/static/js/liveupdate/update.html
@@ -1,4 +1,4 @@
-<time class="live-timestamp" title="<%- thing.fullDate %>" datetime="<%- thing.isoDate %>"></time>
+<time class="live-timestamp" datetime="<%- thing.isoDate %>"></time>
 
 <div class="body">
   <%= thing.body %>

--- a/reddit_liveupdate/templates/liveupdate.html
+++ b/reddit_liveupdate/templates/liveupdate.html
@@ -1,8 +1,11 @@
 <%!
 
   import json
-  from r2.lib.template_helpers import html_datetime
+
+  import pytz
   from babel.dates import format_datetime
+
+  from r2.lib.template_helpers import html_datetime
 
 %>
 
@@ -10,7 +13,7 @@
 <%namespace file="printablebuttons.html" import="ynbutton" />
 
 <li data-fullname="${thing._fullname}" class="liveupdate id-${thing._fullname} ${"stricken" if thing.stricken else ""} ${"pending-embed" if thing.embeds else ""}">
-  <time title="${format_datetime(thing._date, format='long', tzinfo=c.liveupdate_event.timezone, locale=c.locale)}" datetime="${html_datetime(thing._date)}" class="live-timestamp">${thing.date_str}</time>
+  <time title="${format_datetime(thing._date, format='long', tzinfo=pytz.UTC, locale=c.locale)}" datetime="${html_datetime(thing._date)}" class="live-timestamp">${thing.date_str}</time>
 
   <div class="body">
     ${utils.md(thing.body, wrap=True)}

--- a/reddit_liveupdate/templates/liveupdateeventconfiguration.html
+++ b/reddit_liveupdate/templates/liveupdateeventconfiguration.html
@@ -37,7 +37,7 @@ $(function() {
   var $el = $('.danger-zone button');
   var confirmer = new r.ui.ConfirmButton({el: $el});
   $el.on('confirm', function() {
-    $.request('live/${c.liveupdate_event._id}/complete_stream')
+    $.request('live/${c.liveupdate_event._id}/close_stream')
   });
 })
 </script>

--- a/reddit_liveupdate/templates/liveupdateeventconfiguration.html
+++ b/reddit_liveupdate/templates/liveupdateeventconfiguration.html
@@ -23,3 +23,22 @@
     <span class="status error"></span>
   </div>
 </div>
+
+% if c.liveupdate_permissions.allow("close"):
+<%utils:line_field title="${_('close the stream')}" css_class="danger-zone">
+  <p>${_("this will mark the stream as complete and prevent further updates from being added. it cannot be undone.")}</p>
+  <button class="btn" type="button" onclick="">
+    ${_("close stream permanently")}
+  </button>
+</%utils:line_field>
+
+<script>
+$(function() {
+  var $el = $('.danger-zone button');
+  var confirmer = new r.ui.ConfirmButton({el: $el});
+  $el.on('confirm', function() {
+    $.request('live/${c.liveupdate_event._id}/complete_stream')
+  });
+})
+</script>
+% endif

--- a/reddit_liveupdate/templates/liveupdateeventconfiguration.html
+++ b/reddit_liveupdate/templates/liveupdateeventconfiguration.html
@@ -15,32 +15,6 @@
     ${utils.error_field("TOO_LONG", "description")}
   </%utils:line_field>
 
-  <%utils:line_field title="${_('time zone')}" description="${_('which time zone to display updates in')}">
-    <select id="timezone" name="timezone">
-    % for tzname in sorted(thing.ungrouped_timezones):
-    <option value="${tzname}"
-    % if tzname == c.liveupdate_event.timezone:
-    selected
-    % endif
-    >${tzname}</option>
-    % endfor
-
-    % for region in sorted(thing.grouped_timezones):
-    <optgroup label="${region}">
-      % for zone in sorted(thing.grouped_timezones[region]):
-      <option value="${region}/${zone}"
-      % if "%s/%s" % (region, zone) == c.liveupdate_event.timezone:
-      selected
-      % endif
-      >${zone}</option>
-      % endfor
-    </optgroup>
-    % endfor
-    </select>
-
-    ${utils.error_field("INVALID_TIMEZONE", "timezone")}
-  </%utils:line_field>
-
   <div class="save-button">
     <button class="btn" type="button" onclick="return post_pseudo_form('#liveupdate-form', 'live/${c.liveupdate_event._id}/edit')">
       ${_("save settings")}

--- a/reddit_liveupdate/templates/liveupdatelisting.html
+++ b/reddit_liveupdate/templates/liveupdatelisting.html
@@ -9,7 +9,7 @@
 </%def>
 
 <ol class="liveupdate-listing">
-  % for item in thing.things_with_separators():
+  % for item in thing.things:
   ${item}
   % endfor
 </ol>

--- a/reddit_liveupdate/templates/liveupdateseparator.html
+++ b/reddit_liveupdate/templates/liveupdateseparator.html
@@ -1,9 +1,0 @@
-<%!
-
-  from r2.lib.template_helpers import html_datetime
-
-%>
-
-<li class="separator">
-  <time class="live-timestamp absolute" datetime="${html_datetime(thing.date)}">${thing.date_str}</time>
-</li>

--- a/reddit_liveupdate/utils.py
+++ b/reddit_liveupdate/utils.py
@@ -1,5 +1,4 @@
 import datetime
-import itertools
 
 import pytz
 
@@ -9,36 +8,29 @@ from pylons import c
 from r2.lib import websockets, template_helpers
 
 
-def pairwise(iterable):
-    a, b = itertools.tee(iterable)
-    next(b, None)
-    return itertools.izip(a, b)
-
-
 def pretty_time(dt, allow_relative=True):
-    display_tz = pytz.timezone(c.liveupdate_event.timezone)
     ago = datetime.datetime.now(pytz.UTC) - dt
 
     if allow_relative and ago < datetime.timedelta(hours=24):
         return template_helpers.simplified_timesince(dt)
-    elif dt.date() == datetime.datetime.now(display_tz).date():
+    elif dt.date() == datetime.datetime.now(pytz.UTC).date():
         return format_datetime(
             datetime=dt,
-            tzinfo=display_tz,
+            tzinfo=pytz.UTC,
             format="HH:mm",
             locale=c.locale,
         )
     elif ago < datetime.timedelta(days=365):
         return format_datetime(
             datetime=dt,
-            tzinfo=display_tz,
+            tzinfo=pytz.UTC,
             format="dd MMM HH:mm",
             locale=c.locale,
         )
     else:
         return format_datetime(
             datetime=dt,
-            tzinfo=display_tz,
+            tzinfo=pytz.UTC,
             format="dd MMM YYYY HH:mm",
             locale=c.locale,
         )

--- a/reddit_liveupdate/validators.py
+++ b/reddit_liveupdate/validators.py
@@ -1,7 +1,5 @@
 import uuid
 
-import pytz
-
 from pylons import c
 from pylons.controllers.util import abort
 
@@ -48,14 +46,6 @@ class VLiveUpdateContributorWithPermission(Validator):
     def run(self):
         if not c.liveupdate_permissions.allow(self.permission):
             abort(403, "Forbidden")
-
-
-class VTimeZone(Validator):
-    def run(self, timezone_name):
-        try:
-            return pytz.timezone(timezone_name)
-        except pytz.exceptions.UnknownTimeZoneError:
-            self.set_error(errors.INVALID_TIMEZONE)
 
 
 class VLiveUpdatePermissions(VPermissions):


### PR DESCRIPTION
The original intent of the timezone stuff was to mimic the manual live update threads where users would generally timestamp their updates with a provided timezone.  In retrospect, this was likely just due to the limitation of being static text and not actually that helpful to viewers.  Now that moment is in place, it's possible to do this, so user-local timestamps it is!  The separators had to be made client-side only because some timezones vary from UTC in partial hours which would mutate where the separators go.

In the backbonification, I accidentally made the time separators use the older update's hour. This is incorrect because the older update was usually some time _after_ the hour started and so the separator was in the wrong place entirely.  The fix included here brings back the correct placement.

Finally, I've added rudimentary support for closing events. This updates the UI for viewers appropriately. A new permission is added since it's a rather drastic ability as well.

:eyeglasses: @chromakode @umbrae 
