### PR TITLE
Polish and more embeds

### DIFF
--- a/reddit_liveupdate/contrib/simpleflake.py
+++ b/reddit_liveupdate/contrib/simpleflake.py
@@ -1,0 +1,89 @@
+# ========================================================================
+# simple-flake - https://github.com/SawdustSoftware/simple-flake
+# ========================================================================
+
+# Copyright (c) 2013 CustomMade Ventures
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+import time
+import random
+import collections
+
+#: Epoch for simpleflake timestamps, starts at the year 2000
+SIMPLEFLAKE_EPOCH = 946702800
+
+#field lengths in bits
+SIMPLEFLAKE_TIMESTAMP_LENGTH = 41
+SIMPLEFLAKE_RANDOM_LENGTH = 23
+
+#left shift amounts
+SIMPLEFLAKE_RANDOM_SHIFT = 0
+SIMPLEFLAKE_TIMESTAMP_SHIFT = 23
+
+simpleflake_struct = collections.namedtuple("SimpleFlake",
+                                            ["timestamp", "random_bits"])
+
+# ===================== Utility ====================
+
+
+def pad_bytes_to_64(string):
+    return format(string, "064b")
+
+
+def binary(num, padding=True):
+    """Show binary digits of a number, pads to 64 bits unless specified."""
+    binary_digits = "{0:b}".format(int(num))
+    if not padding:
+        return binary_digits
+    return pad_bytes_to_64(int(num))
+
+
+def extract_bits(data, shift, length):
+    """Extract a portion of a bit string. Similar to substr()."""
+    bitmask = ((1 << length) - 1) << shift
+    return ((data & bitmask) >> shift)
+
+# ==================================================
+
+
+def simpleflake(timestamp=None, random_bits=None, epoch=SIMPLEFLAKE_EPOCH):
+    """Generate a 64 bit, roughly-ordered, globally-unique ID."""
+    second_time = timestamp if timestamp is not None else time.time()
+    second_time -= epoch
+    millisecond_time = int(second_time * 1000)
+
+    randomness = random.SystemRandom().getrandbits(SIMPLEFLAKE_RANDOM_LENGTH)
+    randomness = random_bits if random_bits is not None else randomness
+
+    flake = (millisecond_time << SIMPLEFLAKE_TIMESTAMP_SHIFT) + randomness
+
+    return flake
+
+
+def parse_simpleflake(flake):
+    """Parses a simpleflake and returns a named tuple with the parts."""
+    timestamp = SIMPLEFLAKE_EPOCH\
+        + extract_bits(flake,
+                       SIMPLEFLAKE_TIMESTAMP_SHIFT,
+                       SIMPLEFLAKE_TIMESTAMP_LENGTH) / 1000.0
+    random = extract_bits(flake,
+                          SIMPLEFLAKE_RANDOM_SHIFT,
+                          SIMPLEFLAKE_RANDOM_LENGTH)
+    return simpleflake_struct(timestamp, random)

--- a/reddit_liveupdate/media_embeds.py
+++ b/reddit_liveupdate/media_embeds.py
@@ -16,6 +16,7 @@ from r2.lib.db import tdb_cassandra
 from r2.lib.media import MediaEmbed, Scraper, get_media_embed
 from r2.lib.utils import sanitize_url
 
+from reddit_liveupdate import pages
 from reddit_liveupdate.models import LiveUpdateStream, LiveUpdateEvent
 from reddit_liveupdate.utils import send_event_broadcast
 
@@ -129,11 +130,6 @@ class LiveScraper(Scraper):
         return _EmbedlyCardFallbackScraper(url, scraper)
 
 
-_EMBEDLY_CARD_CONTENT = """\
-<a href="%(url)s" class="embedly-card" data-card-chrome="0">%(url)s</a>
-<script src="//cdn.embedly.com/widgets/platform.js"></script>
-"""
-
 
 class _EmbedlyCardFallbackScraper(Scraper):
     def __init__(self, url, scraper):
@@ -150,9 +146,7 @@ class _EmbedlyCardFallbackScraper(Scraper):
                 "oembed": {
                     "width": _EMBED_WIDTH,
                     "height": 0,
-                    "html": _EMBEDLY_CARD_CONTENT % {
-                        "url": self.url,
-                    },
+                    "html": pages.EmbedlyCard(self.url).render(style="html"),
                 },
             }
 

--- a/reddit_liveupdate/models.py
+++ b/reddit_liveupdate/models.py
@@ -1,4 +1,3 @@
-import base64
 import datetime
 import json
 import uuid
@@ -12,7 +11,7 @@ from r2.lib import utils
 from r2.lib.db import tdb_cassandra
 from r2.models import query_cache
 
-
+from reddit_liveupdate.contrib import simpleflake
 from reddit_liveupdate.permissions import ContributorPermissionSet
 
 
@@ -78,7 +77,7 @@ class LiveUpdateEvent(tdb_cassandra.Thing):
     @classmethod
     def new(cls, id, title, **properties):
         if not id:
-            id = base64.b32encode(uuid.uuid1().bytes).rstrip("=").lower()
+            id = utils.to36(simpleflake.simpleflake())
         event = cls(id, title=title, **properties)
         event._commit()
         return event

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -441,3 +441,9 @@ def liveupdate_add_props(user, wrapped):
 
 class LiveUpdateCreate(Templated):
     pass
+
+
+class EmbedlyCard(Templated):
+    def __init__(self, url):
+        self.url = url
+        Templated.__init__(self)

--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -596,6 +596,7 @@ body.liveupdate-app {
         // device and hover doesn't work so well there.
         ul.buttonrow {
             display: block !important; // make up for super-specificity of the other rule
+            margin-left: 0 !important;
         }
     }
 

--- a/reddit_liveupdate/public/static/js/liveupdate/embeds.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/embeds.js
@@ -40,7 +40,12 @@
       $el.removeClass('pending-embed')
 
       _.each(embeds, function(embed, embedIndex) {
-        var $link = $el.find('a[href="' + embed.url + '"]')
+        var $placeholder = $el
+          .find('p')
+          .has('a[href="' + embed.url + '"]')
+          .filter(function() {
+            return $(this).contents().length === 1
+          })
         var embedUri = this._embedBase + '/' + updateId + '/' + embedIndex
         var iframe = $('<iframe>').attr({
           'class': 'embedFrame',
@@ -51,8 +56,8 @@
           'scrolling': 'no',
           'frameborder': 0,
         })
-        r.debug('Rendering embed for link: ', $link)
-        $link.replaceWith(iframe)
+        r.debug('Rendering embed for link: ', embed.url)
+        $placeholder.replaceWith(iframe)
       }, this)
     },
 

--- a/reddit_liveupdate/public/static/js/liveupdate/listings.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/listings.js
@@ -324,8 +324,15 @@
     },
 
     onRemove: function(update) {
-      // TODO: merge/delete orphaned separators
-      this.views[update.id].remove()
+      var view = this.views[update.id]
+
+      // remove orphaned separators
+      view.$el
+        .nextUntil('.liveupdate')
+        .remove()
+
+      // remove self
+      view.remove()
       delete this.views[update.id]
     },
 

--- a/reddit_liveupdate/templates/embedlycard.html
+++ b/reddit_liveupdate/templates/embedlycard.html
@@ -1,0 +1,2 @@
+<a href="${thing.url}" class="embedly-card" data-card-chrome="0">${thing.url}</a>
+<script src="//cdn.embedly.com/widgets/platform.js"></script>


### PR DESCRIPTION
This starts out as a few bugfix/polish fixes that I was working on then veers to embeds.
- 396f543: Example of a new-style URL `/live/t4eim4330dxh` vs. old-style: `/live/7jikpyx3yei6hlmbfintwaizsq`. Explanation of the algorithm: http://engineering.custommade.com/simpleflake-distributed-id-generation-for-the-lazy/
- 817f01a: Fixes an issue where you get a bunch of separators stacking up next to each other.
- 3d870c5: Simple visual fix for narrow screen mode.
- e2304fc: An update like "http://youtube.com/whatever\n\nSource: http://youtube.com/whatever" would accidentally replace both the links despite only the first one being an embed according to our embed semantics. This fix was requested by the UkrainianConflict people.
- 66c47e9: Adds a scraper that is only used when the Embedly-oembed and twitter scrapers fail.  This one makes an Embedly card for the URL which is useful for static photos (on e.g. imgur or instagram) or news articles etc.

![banana](https://cloud.githubusercontent.com/assets/338853/3379394/20e44c04-fbf1-11e3-8d11-009860639b2e.png)

:eyeglasses: @umbrae 
