### PR TITLE
Add tagline and faq link to homepage.

### DIFF
--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -804,4 +804,9 @@ aside.sidebar {
         text-align: center;
         margin-bottom: 3em;
     }
+
+    .tagline {
+        margin-top: 1em;
+        color: #000;
+    }
 }

--- a/reddit_liveupdate/templates/liveupdatehome.html
+++ b/reddit_liveupdate/templates/liveupdatehome.html
@@ -1,5 +1,9 @@
+<%namespace file="utils.html" name="utils" />
+
 <h1 id="liveupdate-logo">${_("reddit live")}</h1>
+
+<p class="tagline">${_("follow live events as they happen")}</p>
 
 <a href="/live/create" class="liveupdate-meta-button">${_("make a new live thread")}</a>
 
-<p><a href="/r/live">${_("or check out /r/live for more info")}</a></p>
+<p><a href="/r/live/wiki/index">${utils._md("[read the FAQ](/r/live/wiki/index) or [check out /r/live for more info](/r/live)")}</a></p>


### PR DESCRIPTION
@spladug

Adds a descriptive tagline to the live homepage and a link to the faq (which is more straightforwardly explanatory than /r/live).

![screenshot 2014-09-03 10 31 10](https://cloud.githubusercontent.com/assets/1231913/4138438/fb7fd910-3390-11e4-8f06-3978184c6b6a.png)
