### PR TITLE
Remove GA Heartbeat event

### DIFF
--- a/reddit_liveupdate/public/static/js/liveupdate/activity.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/activity.js
@@ -29,14 +29,6 @@
       var pixel
       var delay
 
-      // we don't need to fire a heartbeat for GA on the first pixel request,
-      // also google analytics might not be enabled, so only use this if we're
-      // sure it's safe
-      if (this.reportsSent > 0 && window._gaq) {
-        // FIXME: do something when we hit the 500 ping limit
-        _gaq.push(['_trackEvent', 'Heartbeat', 'Heartbeat', '', 0, true])
-      }
-
       pixel = new Image()
       pixel.src = '//' + r.config.liveupdate_pixel_domain +
         '/live/' + r.config.liveupdate_event + '/pixel.png' +


### PR DESCRIPTION
:eyeglasses: @umbrae @spladug - is this okay, or should we sample it down instead?

Context: removing GA events because we're sending too many.
