### PR TITLE
Add permissions to contributor listing JSON... PROPERLY

### DIFF
--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -204,6 +204,8 @@ class LiveUpdate(Plugin):
         api('liveupdateevent', pages.LiveUpdateEventJsonTemplate)
         api('liveupdatereportedeventrow', pages.LiveUpdateEventJsonTemplate)
         api('liveupdate', pages.LiveUpdateJsonTemplate)
+        api('liveupdatecontributortableitem',
+            pages.ContributorTableItemJsonTemplate)
 
         from reddit_liveupdate import scraper
         scraper.hooks.register_all()

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -150,7 +150,7 @@ class LiveUpdateContributorBuilder(SimpleBuilder):
         return not item.account._deleted
 
     def wrap_item(self, item):
-        return pages.ContributorTableItem(
+        return pages.LiveUpdateContributorTableItem(
             item,
             self.event,
             editable=self.editable,
@@ -165,7 +165,7 @@ class LiveUpdateContributorBuilder(SimpleBuilder):
 
 class LiveUpdateInvitedContributorBuilder(LiveUpdateContributorBuilder):
     def wrap_item(self, item):
-        return pages.InvitedContributorTableItem(
+        return pages.InvitedLiveUpdateContributorTableItem(
             item,
             self.event,
             editable=self.editable,
@@ -562,7 +562,7 @@ class LiveUpdateController(RedditController):
 
         # add the user to the table
         contributor = LiveUpdateContributor(user, permissions)
-        user_row = pages.InvitedContributorTableItem(
+        user_row = pages.InvitedLiveUpdateContributorTableItem(
             contributor, c.liveupdate_event, editable=True)
         jquery(".liveupdate_contributor_invite-table").show(
             ).find("table").insert_table_rows(user_row)

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -23,6 +23,7 @@ from r2.lib.jsontemplates import (
     JsonTemplate,
     ObjectTemplate,
     ThingJsonTemplate,
+    UserTableItemJsonTemplate,
 )
 
 from reddit_liveupdate.permissions import ContributorPermissionSet
@@ -267,12 +268,12 @@ class LiveUpdateContributorPermissions(ModeratorPermissions):
         )
 
 
-class ContributorTableItem(UserTableItem):
+class LiveUpdateContributorTableItem(UserTableItem):
     type = "liveupdate_contributor"
 
     def __init__(self, contributor, event, editable):
         self.event = event
-        self.render_class = ContributorTableItem
+        self.render_class = LiveUpdateContributorTableItem
         self.permissions = LiveUpdateContributorPermissions(
             self.type, contributor.account, contributor.permissions)
         UserTableItem.__init__(self, contributor.account, editable=editable)
@@ -302,12 +303,25 @@ class ContributorTableItem(UserTableItem):
         return "live/%s/rm_contributor" % self.event._id
 
 
-class InvitedContributorTableItem(ContributorTableItem):
+class InvitedLiveUpdateContributorTableItem(LiveUpdateContributorTableItem):
     type = "liveupdate_contributor_invite"
 
     @property
     def remove_action(self):
         return "live/%s/rm_contributor_invite" % self.event._id
+
+
+class ContributorTableItemJsonTemplate(UserTableItemJsonTemplate):
+    _data_attrs_ = UserTableItemJsonTemplate.data_attrs(
+        permissions="permissions",
+    )
+
+    def thing_attr(self, thing, attr):
+        if attr == "permissions":
+            return [perm for perm, has in
+                thing.permissions.permissions.iteritems() if has]
+        else:
+            return UserTableItemJsonTemplate.thing_attr(self, thing, attr)
 
 
 class LiveUpdateInvitedContributorListing(UserListing):


### PR DESCRIPTION
Take 2 at adding permissions to the contributors JSON.  

This requires renaming our ContributorTableItem because when it gets a
JSON representation it starts conflicting with r2's.  In general, the
view models in plugins should stay prefixed to avoid this kind of mess
so this is just good practice anyway.

:eyeglasses: @JordanMilne 
