### PR TITLE
Fix javascript loading for SSL embeds.

### DIFF
--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -176,6 +176,10 @@ class LiveUpdateEventEmbed(LiveUpdateEventPage):
     def __init__(self, *args, **kwargs):
         self.base_url = add_sr(
             "/live/" + c.liveupdate_event._id, force_hostname=True)
+        # add_sr doesn't change the scheme for non-reddit URLs and
+        # g.media_domain (where embeds are) is a non-reddit URL
+        if c.secure:
+            self.base_url = self.base_url.replace("http://", "https://", 1)
         super(LiveUpdateEventEmbed, self).__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
In production, liveupdate embeds are hosted on a off-cookie-domain. This
domain would also fail the is_reddit_url test which would mean that the base
URL wouldn't be set as secure even if the client connection was secure. This
would in turn cause javascript to not execute because it was loaded
insecurely.

I thought of a couple other ways to do this — changing `is_reddit_url` to allow `g.media_domain`, or adding a `force_protocol` option to `add_sr` — but both seem too heavy handed. I'm open to suggestions for better ways.

:eyeglasses: @spladug @umbrae 
