### PR TITLE
Fix javascript loading for SSL embeds.

### DIFF
--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -175,7 +175,10 @@ class LiveUpdateEventEmbed(LiveUpdateEventPage):
 
     def __init__(self, *args, **kwargs):
         self.base_url = add_sr(
-            "/live/" + c.liveupdate_event._id, force_hostname=True)
+            "/live/" + c.liveupdate_event._id,
+            force_hostname=True,
+            force_https=c.secure,
+        )
         super(LiveUpdateEventEmbed, self).__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
In production, liveupdate embeds are hosted on a off-cookie-domain. This
domain would also fail the is_reddit_url test which would mean that the base
URL wouldn't be set as secure even if the client connection was secure. This
would in turn cause javascript to not execute because it was loaded
insecurely.

This is a companion to the reddit pull request that adds `force_https` to `add_sr`
:eyeglasses: @umbrae 
