### PR TITLE
Fix markdown font sizes in sidebar.

### DIFF
--- a/reddit_liveupdate/templates/liveupdateeventapp.html
+++ b/reddit_liveupdate/templates/liveupdateeventapp.html
@@ -36,7 +36,7 @@
 
 <div class="main-content">
 % if thing.show_sidebar:
-<aside class="sidebar">
+<aside class="sidebar side md-container">
   % if thing.event.description:
   <section id="liveupdate-description">
     ${utils.md(thing.event.description, wrap=True)}


### PR DESCRIPTION
Currently, the liveupdate sidebar's font-size gets _pretty small_ (about 10px) when the new markdown styles are applied to it. This makes the liveupdate sidebar inherit the markdown styles from the main site's sidebar, which has a more reasonable font size of 12px;

:eyeglasses: @spladug 
