### PR TITLE
Remove unnecessary unsafe()

### DIFF
--- a/reddit_liveupdate/templates/liveupdateeventapp.html
+++ b/reddit_liveupdate/templates/liveupdateeventapp.html
@@ -62,7 +62,7 @@
     </ul>
 
     % if len(thing.contributors) > CONTRIBUTOR_CUTOFF:
-    <a href="/live/${c.liveupdate_event._id}/contributors" class="more-contributors">${unsafe(_("&hellip; and %(count)s more &raquo;") % dict(count=len(thing.contributors) - CONTRIBUTOR_CUTOFF))}</a>
+    <a href="/live/${c.liveupdate_event._id}/contributors" class="more-contributors">${_("… and %(count)s more ⇒") % dict(count=len(thing.contributors) - CONTRIBUTOR_CUTOFF)}</a>
     % endif
   </section>
 


### PR DESCRIPTION
:eyeglasses: @spladug @florenceyeun 

We're fine to use the raw characters here instead of HTML entities, we send a `Content-Type` of `UTF-8`.
