### PR TITLE
Toggleable sidebar content for mobile

### DIFF
--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -629,7 +629,6 @@ aside.sidebar {
         border: 1px solid #ccc;
         background-color: #fafafa;
         padding: 10px;
-        font-size: 13px;
 
         .sidebar-expand {
             display: inline-block;

--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -26,9 +26,11 @@
 }
 
 body {
+    min-width: @full-width + @container-horizontal-padding * 2 + @container-border-width * 2;
     background-color: @outside-background-color;
 
     &.embed {
+        min-width: 0;
         background-color: white;
     }
 }
@@ -37,7 +39,7 @@ body {
     @border-radius: 7px;
 
     margin: 0 auto;
-    max-width: @full-width;
+    width: @full-width;
     border: @container-border-width solid @container-border-color;
     border-top: none;
     border-radius: 0 0 @border-radius @border-radius;
@@ -54,6 +56,7 @@ body {
     }
 
     body.embed & {
+        width: auto;
         border: 0;
     }
 }
@@ -226,15 +229,11 @@ body {
         background: url(../throbber.gif) center bottom no-repeat;
     }
 
-    .embed & {
-        width: @listing-width;
-    }
-
     li.separator {
         color: #808080;
         font-size: 13px;
         text-align: center;
-        margin-bottom: 2em;
+        margin-bottom: 1em;
         position: relative;
         background: transparent;
         z-index: 0;
@@ -264,12 +263,12 @@ body {
 
             display: inline-block;
             font-size: 10px;
-            max-width: @time-col-width - @bauble-width;
-            min-width: @time-col-width - @bauble-width;
+            width: @time-col-width - @bauble-width;
             text-align: left;
             overflow: hidden;
             float: left;
             vertical-align: top;
+            margin-bottom: .5em;
             padding-top: 3px;
 
             color: #888;
@@ -300,7 +299,7 @@ body {
             width: 100%;
             max-width: @update-col-width;
             word-break: break-word;
-            padding-bottom: 1em;
+            margin-bottom: 1em;
             font-size: 13px;
 
             div.md {
@@ -556,14 +555,15 @@ aside.sidebar {
 
 @media all and (max-width: 700px) {
     body {
+        min-width: 0;
         background-color: #fff;
     }
 
     .content,
     .liveupdate-focus .content {
-        max-width: 95%;
+        width: auto;
         border: none;
-        padding: 0;
+        padding: 0 10px;
         margin: 0 auto;
     }
 
@@ -602,7 +602,6 @@ aside.sidebar {
     aside.sidebar {
         float: none;
         margin: 0 0 2em 0;
-        max-width: 700px;
         width: auto;
         opacity: 1;
         transition: opacity 0;
@@ -652,11 +651,27 @@ aside.sidebar {
     }
 
     .liveupdate-listing {
-        max-width: 700px;
+        max-width: none;
 
-        li.liveupdate time {
-            margin-bottom: .5em;
-            padding-left: 15px;
+        .embed & {
+            width: auto;
+        }
+
+        li.separator {
+            margin-left: 0;
+            margin-rigth: 0;
+        }
+
+        li.liveupdate {
+            time {
+                float: none;
+                width: auto;
+                padding-left: 15px;
+            }
+
+            .body {
+                display: block;
+            }
         }
 
         // always display the buttons in tiny-screen mode since it's likely a touch

--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -84,6 +84,10 @@ body {
     }
 }
 
+#liveupdate-description {
+    margin-bottom: 10px;
+}
+
 .blink-animation(@opacity: .1) {
     to {
         opacity: @opacity;
@@ -410,26 +414,23 @@ aside.sidebar {
     margin-left: 30px;
     opacity: 0.5;
     transition: opacity @transition-time;
+    overflow: hidden;
 
     &:hover {
         opacity: 1;
         transition: opacity @transition-time;
     }
 
-    h1 {
-        font-size: 18px;
-    }
+    .sidebar-expand {
+        display: none;
+        font-size: 12px;
 
-    h2 {
-        font-size: 16px;
-        color: #000;
-        font-weight: normal;
-    }
-
-    h3, h4, h5, h6 {
-        color: #000;
-        font-size: 14px;
-        font-weight: bold;
+        &:before {
+            content: '[+] ';
+            padding: 1px;
+            font-size: 10px;
+            vertical-align: 1px;
+        }
     }
 
     p {
@@ -437,20 +438,42 @@ aside.sidebar {
     }
 
     section {
+        margin-top: 1em;
         margin-bottom: .7em;
-    }
-
-    section:not(:first-child){
         border-top: 1px dotted #999;
+        padding-top: .7em;
+
+        &:first-of-type {
+            border-top: none;
+            padding-top: 0;
+        }
+
+        > h2 {
+            margin-bottom: 10px;
+            font-size: 18px;
+            font-weight: normal;
+            color: inherit;
+        }
     }
 
     .md {
         overflow-wrap: break-word;
         word-wrap: break-word; //support for firefox and IE
+
+        h2 {
+            font-size: 16px;
+            color: #000;
+            font-weight: normal;
+        }
+
+        h3, h4, h5, h6 {
+            color: #000;
+            font-size: 14px;
+            font-weight: bold;
+        }
     }
 
     #discussions {
-
         p {
             margin: .3em 0;
         }
@@ -578,6 +601,11 @@ aside.sidebar {
         }
     }
 
+    // hide popup notifications checkbox for small screens
+    #liveupdate-options {
+        display: none;
+    }
+
     .main-content {
         margin-top: 1em;
     }
@@ -591,14 +619,6 @@ aside.sidebar {
         }
     }
 
-    #liveupdate-options {
-        float: none;
-        clear: both;
-        margin-top: 1em;
-        text-align: right;
-        width: auto;
-    }
-
     aside.sidebar {
         float: none;
         margin: 0 0 2em 0;
@@ -606,24 +626,30 @@ aside.sidebar {
         opacity: 1;
         transition: opacity 0;
 
+        border: 1px solid #ccc;
+        background-color: #fafafa;
+        padding: 10px;
+        font-size: 13px;
+
+        .sidebar-expand {
+            display: inline-block;
+        }
+
+        &.sidebar-expanded {
+            section {
+                display: block;
+            }
+            .sidebar-expand:before {
+                content: '[-] ';
+            }
+        }
+
         section {
-            border: 1px solid #ccc;
-            background-color: #fafafa;
-            padding: 10px;
-            font-size: 13px;
+            display: none;
+        }
 
-            h1 {
-                margin-top: 0;
-                font-size: 18px;
-            }
-
-            &:not(:first-child){
-                border: 1px solid #ccc;
-            }
-
-            .md {
-                max-width: none;
-            }
+        .md {
+            max-width: none;
         }
 
         #discussions {

--- a/reddit_liveupdate/public/static/js/liveupdate/event.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/event.js
@@ -24,7 +24,7 @@
       this.$resourcesEl = $('#liveupdate-resources')
 
       if (!this.$descriptionEl.length) {
-        this.$descriptionEl = $('<section id="liveupdate-description">')
+        this.$descriptionEl = $('<div id="liveupdate-description">')
       }
 
       if (!this.$resourcesEl.length) {
@@ -52,7 +52,7 @@
 
       this.$descriptionEl
         .html(description)
-        .prependTo('aside.sidebar')
+        .insertAfter(this.$titleEl)
     },
 
     renderResources: function() {
@@ -65,12 +65,7 @@
       }
 
       this.$resourcesEl.find('.md').replaceWith($.parseHTML(resources))
-
-      if ($('html').has(this.$descriptionEl).length) {
-        this.$resourcesEl.insertAfter(this.$descriptionEl)
-      } else {
-        this.$resourcesEl.prependTo('aside.sidebar')
-      }
+      this.$resourcesEl.insertAfter('.sidebar-expand')
     },
   })
 }(r, Backbone, jQuery)

--- a/reddit_liveupdate/public/static/js/liveupdate/event.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/event.js
@@ -29,7 +29,7 @@
 
       if (!this.$resourcesEl.length) {
         this.$resourcesEl = $('<section id="liveupdate-resources">')
-        this.$resourcesEl.append($('<h1>' + r._('resources') + '</h1>'))
+        this.$resourcesEl.append($('<h2>' + r._('resources') + '</h2>'))
       }
 
       this.listenTo(this.model, {

--- a/reddit_liveupdate/public/static/js/liveupdate/init.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/init.js
@@ -142,4 +142,16 @@ $(function() {
   } else if ($body.hasClass('liveupdate-focus')) {
     r.liveupdate.app = new r.liveupdate.LiveUpdateAppBase()
   }
+
+  $('.sidebar-expand').on('click', function(e) {
+    var $this = $(this)
+    var toggleText = $this.data('toggle')
+    var currentText = $this.text()
+
+    $this
+      .text(toggleText)
+      .data('toggle', currentText)
+      .parent().toggleClass('sidebar-expanded')
+  });
+
 })

--- a/reddit_liveupdate/templates/liveupdateeventapp.html
+++ b/reddit_liveupdate/templates/liveupdateeventapp.html
@@ -9,7 +9,7 @@
 <header id="liveupdate-header">
   <h1 id="liveupdate-title">${thing.event.title}</h1>
   % if thing.event.description:
-  <div id="liveupdate-description">
+  <div id="liveupdate-description" class="md-container">
     ${utils.md(thing.event.description, wrap=True)}
   </div>
   % endif

--- a/reddit_liveupdate/templates/liveupdateeventapp.html
+++ b/reddit_liveupdate/templates/liveupdateeventapp.html
@@ -8,6 +8,11 @@
 
 <header id="liveupdate-header">
   <h1 id="liveupdate-title">${thing.event.title}</h1>
+  % if thing.event.description:
+  <div id="liveupdate-description">
+    ${utils.md(thing.event.description, wrap=True)}
+  </div>
+  % endif
 
   <div id="liveupdate-statusbar" class="${thing.event.state}">
     <p class="state">
@@ -37,23 +42,19 @@
 <div class="main-content">
 % if thing.show_sidebar:
 <aside class="sidebar side md-container">
-  % if thing.event.description:
-  <section id="liveupdate-description">
-    ${utils.md(thing.event.description, wrap=True)}
-  </section>
-  % endif
+  <a class="sidebar-expand" href="javascript: void 0;" data-toggle="${_("less about this live thread")}">${_("more about this live thread")}</a>
   % if thing.event.resources:
   <section id="liveupdate-resources">
-    <h1>${_("resources")}</h1>
+    <h2>${_("resources")}</h2>
     ${utils.md(thing.event.resources, wrap=True)}
   </section>
   % endif
   <section id="discussions" title="${_("comment threads on reddit linking to this page")}">
-    <h1>${_("discussions")}</h1>
+    <h2>${_("discussions")}</h2>
     ${thing.discussions}
   </section>
   <section id="contributors">
-    <h1>${_("updated by")}</h1>
+    <h2>${_("updated by")}</h2>
 
     <ul>
       % for contributor in thing.contributors[:CONTRIBUTOR_CUTOFF]:


### PR DESCRIPTION
Hide sidebar content and add a toggle link for mobile.  Generally attempt to improve responsiveness and adjust spacing.

Before:
![screen shot 2015-01-30 at 2 03 38 pm](https://cloud.githubusercontent.com/assets/1264297/5984242/4b13061a-a889-11e4-83c4-f9547b544d62.png)

After:
![screen shot 2015-01-30 at 2 03 40 pm](https://cloud.githubusercontent.com/assets/1264297/5984243/500d9a36-a889-11e4-9283-702bffc701cb.png)

Before:
![screen shot 2015-01-30 at 2 04 26 pm](https://cloud.githubusercontent.com/assets/1264297/5984247/58892ab8-a889-11e4-8987-f97b7d58eebe.png)

After:
![screen shot 2015-01-30 at 2 04 15 pm](https://cloud.githubusercontent.com/assets/1264297/5984253/600149d8-a889-11e4-9b47-ada70673fbd0.png)

:eyeglasses: @spladug @madbook 
