### PR TITLE
Reset min-width for embedded live thread

### DIFF
--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -685,6 +685,7 @@ aside.sidebar {
 
         .embed & {
             width: auto;
+            min-width: 0;
         }
 
         li.separator {


### PR DESCRIPTION
This addresses clipped content on mobile devices when a live thread is embedded.

Before and after:
<img src="https://cloud.githubusercontent.com/assets/1264297/9186257/e763620a-3f77-11e5-8dab-c63095bd1ac9.png" width="50%"><img src="https://cloud.githubusercontent.com/assets/1264297/9186260/eb76bdce-3f77-11e5-8f11-6e135f89782d.png" width="50%">

:eyeglasses: @madbook 
