### PR TITLE
Add NSFW attribute to event's about JSON

### DIFF
--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -192,6 +192,7 @@ class LiveUpdateEventJsonTemplate(ThingJsonTemplate):
         viewer_count="viewer_count",
         viewer_count_fuzzed="viewer_count_fuzzed",
         title="title",
+        nsfw="nsfw",
         description="description",
         description_html="description_html",
         resources="resources",


### PR DESCRIPTION
Previously there seems to be no way to get the NSFW attribute of an event via the API.
