### PR TITLE
Broadcast event's NSFW attribute over websocket when modified

### DIFF
--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -453,6 +453,8 @@ class LiveUpdateController(RedditController):
         if resources != c.liveupdate_event.resources:
             changes["resources"] = resources
             changes["resources_html"] = safemarkdown(resources, nofollow=True) or ""
+        if nsfw != c.liveupdate_event.nsfw:
+            changes["nsfw"] = nsfw
         _broadcast(type="settings", payload=changes)
 
         c.liveupdate_event.title = title


### PR DESCRIPTION
Currently when modifying an event's NSFW attribute a `settings` message is broadcast over the websocket but that never contains the NSFW attribute change. When only NSFW attribute gets changed the payload will be an empty JSON object. This patch aims to fix this missing behavior.
