### PR TITLE
Fix extra whitespace below media embeds. And a minor resizing issue.

### DIFF
--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -398,6 +398,7 @@ body {
 
 .embedFrame {
     border: 0;
+    width: 100%;
     max-width: 100%;
 }
 

--- a/reddit_liveupdate/public/static/js/liveupdate/embeds.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/embeds.js
@@ -51,7 +51,6 @@
           'class': 'embedFrame',
           'id': 'embed-' + updateId + '-' + embedIndex,
           'src': embedUri,
-          'width': embed.width,
           'height': embed.height || 200,
           'scrolling': 'no',
           'frameborder': 0,
@@ -74,7 +73,6 @@
       if (data.action === 'dimensionsChange') {
         $('#embed-LiveUpdate_' + data.updateId + '-' + data.embedIndex)
           .attr({
-            'width': Math.min(data.width, 480),
             'height': data.height,
           })
       }

--- a/reddit_liveupdate/templates/liveupdatemediaembedbody.html
+++ b/reddit_liveupdate/templates/liveupdatemediaembedbody.html
@@ -45,7 +45,7 @@
         if ('MutationObserver' in window) {
             /* Currently just check on every set of mutations. */
             var observer = new MutationObserver(checkDimensions),
-                config = { attributes: true, subtree: true};
+                config = { attributes: true, subtree: true, childList: true};
 
             observer.observe(root, config);
         } else {


### PR DESCRIPTION
Fixes a visual bug in media embeds having extraneous whitespace before
the author. This is really common on Twitter embeds.

https://reddit.atlassian.net/browse/WEB-1217

Also fixes an issue with the embed shrinking in width when the
page is resized, and never growing back to its proper size.

Tested with various Twitter and Imgur embeds.

Some threads on my staging
[SuperSmash](https://schwers.staging.wireddit.com/live/tsdh1ylqjv3b)
[Pluto](https://schwers.staging.wireddit.com/live/v8j2tqin01cf)
[Paris](https://schwers.staging.wireddit.com/live/vwwnkuplwr9y)

:eyeglasses: @florenceyeun @umbrae @spez 
