### PR TITLE
activity: Increase consistency levels to improve count accuracy

### DIFF
--- a/reddit_liveupdate/models.py
+++ b/reddit_liveupdate/models.py
@@ -234,8 +234,8 @@ class ActiveVisitorsByLiveUpdateEvent(tdb_cassandra.View):
         key_validation_class=tdb_cassandra.ASCII_TYPE,
     )
 
-    _read_consistency_level  = tdb_cassandra.CL.ONE
-    _write_consistency_level = tdb_cassandra.CL.ANY
+    _read_consistency_level  = tdb_cassandra.CL.QUORUM
+    _write_consistency_level = tdb_cassandra.CL.ONE
 
     @classmethod
     def touch(cls, event_id, hash):


### PR DESCRIPTION
This is a stab in the dark. The counts are way lower than they should
be. The cron job using ONE is probably a bad idea since read counts are
so low.

:eyeglasses: @bsimpson63 
