### PR TITLE
Broadcast settings change only when changes were actually made

### DIFF
--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -455,7 +455,9 @@ class LiveUpdateController(RedditController):
             changes["resources_html"] = safemarkdown(resources, nofollow=True) or ""
         if nsfw != c.liveupdate_event.nsfw:
             changes["nsfw"] = nsfw
-        _broadcast(type="settings", payload=changes)
+        
+        if changes:
+            _broadcast(type="settings", payload=changes)
 
         c.liveupdate_event.title = title
         c.liveupdate_event.description = description


### PR DESCRIPTION
Saving event settings without making a single modification causes the settings change to be pushed out over the WebSocket with empty payload. This patch avoids broadcasting empty settings changes.
