### PR TITLE
Atom: <published/> -> <updated/>

### DIFF
--- a/reddit_liveupdate/templates/liveupdate.xml
+++ b/reddit_liveupdate/templates/liveupdate.xml
@@ -32,5 +32,5 @@
     </%utils:atom_content>
     <id>${thing._fullname}</id>
     <link href="${url}" />
-    <published>${html_datetime(thing._date)}</published>
+    <updated>${html_datetime(thing._date)}</updated>
 </entry>


### PR DESCRIPTION
Atom requires `<updated/>` and does not require `<published/>`. This is a simple
rename of this field
