### PR TITLE
Transition to activity service for viewer counts

### DIFF
--- a/reddit_liveupdate/activity.py
+++ b/reddit_liveupdate/activity.py
@@ -9,7 +9,6 @@ from r2.lib.db import tdb_cassandra
 from r2.models.query_cache import CachedQueryMutator
 
 from reddit_liveupdate.models import (
-    ActiveVisitorsByLiveUpdateEvent,
     LiveUpdateEvent,
     LiveUpdateActivityHistoryByEvent,
 )

--- a/reddit_liveupdate/activity.py
+++ b/reddit_liveupdate/activity.py
@@ -20,11 +20,10 @@ def update_activity():
     events = {}
     event_counts = collections.Counter()
 
-    for chunk in utils.in_chunks(LiveUpdateEvent._all(), size=100):
-        context_ids = {"LiveUpdateEvent_" + ev._id: ev._id for ev in chunk
-                       if ev.state == "live" and not ev.banned}
-        if not context_ids:
-            continue
+    query = (ev for ev in LiveUpdateEvent._all()
+             if ev.state == "live" and not ev.banned)
+    for chunk in utils.in_chunks(query, size=100):
+        context_ids = {"LiveUpdateEvent_" + ev._id: ev._id for ev in chunk}
 
         try:
             with c.activity_service.retrying() as svc:

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -72,7 +72,6 @@ from reddit_liveupdate.models import (
     LiveUpdateContributorInvitesByEvent,
     LiveUpdateReportsByAccount,
     LiveUpdateReportsByEvent,
-    ActiveVisitorsByLiveUpdateEvent,
 )
 from reddit_liveupdate.permissions import ContributorPermissionSet
 from reddit_liveupdate.utils import send_event_broadcast
@@ -208,7 +207,6 @@ class LiveUpdatePixelController(BaseController):
         event_id = event[:50]  # some very simple poor-man's validation
         user_agent = request.user_agent or ''
         user_id = hashlib.sha1(request.ip + user_agent).hexdigest()
-        ActiveVisitorsByLiveUpdateEvent.touch(event_id, user_id)
 
         if c.activity_service:
             event_context_id = "LiveUpdateEvent_" + event_id

--- a/reddit_liveupdate/models.py
+++ b/reddit_liveupdate/models.py
@@ -225,27 +225,6 @@ class LiveUpdate(object):
         return embeds
 
 
-class ActiveVisitorsByLiveUpdateEvent(tdb_cassandra.View):
-    _use_db = True
-    _connection_pool = 'main'
-    _ttl = datetime.timedelta(minutes=15)
-
-    _extra_schema_creation_args = dict(
-        key_validation_class=tdb_cassandra.ASCII_TYPE,
-    )
-
-    _read_consistency_level  = tdb_cassandra.CL.QUORUM
-    _write_consistency_level = tdb_cassandra.CL.ONE
-
-    @classmethod
-    def touch(cls, event_id, hash):
-        cls._set_values(event_id, {hash: ''})
-
-    @classmethod
-    def get_count(cls, event_id):
-        return cls._cf.get_count(event_id)
-
-
 class LiveUpdateActivityHistoryByEvent(tdb_cassandra.View):
     _use_db = True
     _connection_pool = "main"


### PR DESCRIPTION
This transitions to the activity service and is intended for each commit to be deployed separately. 

Later, we can move off the liveupdate pixel endpoint to the activity service gateway to offload that aspect from the r2 stack.

:eyeglasses: @dellis23 @bsimpson63 
