### PR TITLE
Add proper open graph tags to update focus pages

### DIFF
--- a/reddit_liveupdate/models.py
+++ b/reddit_liveupdate/models.py
@@ -157,10 +157,6 @@ class LiveUpdateStream(tdb_cassandra.View):
         return [LiveUpdate.from_json(*column.popitem())
                 for column in utils.tup(columns)]
 
-    @classmethod
-    def query_focus(cls, event, id):
-        return FocusQuery([cls.get_update(event, id)])
-
 
 class LiveUpdate(object):
     __slots__ = ("_id", "_data")

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -158,7 +158,7 @@ class LiveUpdateEventAppPage(LiveUpdateEventPage):
             "image": static("liveupdate-logo.png"),
             "image:width": "300",
             "image:height": "300",
-            "site_name": g.short_description,
+            "site_name": "reddit",
             "ttl": "600",  # have this stuff re-fetched frequently
         }
 
@@ -180,7 +180,7 @@ class LiveUpdateEventFocusPage(LiveUpdateEventPage):
             "image": static("liveupdate-logo.png"),
             "image:width": "300",
             "image:height": "300",
-            "site_name": g.short_description,
+            "site_name": "reddit",
         }
 
         LiveUpdateEventPage.__init__(

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -11,6 +11,7 @@ from r2.lib.pages import (
     UserTableItem,
     MediaEmbedBody,
     ModeratorPermissions,
+    MAX_DESCRIPTION_LENGTH,
 )
 from r2.lib.menus import NavMenu, NavButton
 from r2.lib.template_helpers import add_sr
@@ -19,7 +20,7 @@ from r2.lib.wrapped import Templated, Wrapped
 from r2.models import Account, Subreddit, Link, NotFound, Listing, UserListing
 from r2.lib.strings import strings
 from r2.lib.template_helpers import static
-from r2.lib.utils import tup
+from r2.lib.utils import tup, trunc_string
 from r2.lib.jsontemplates import (
     JsonTemplate,
     ObjectTemplate,
@@ -170,6 +171,24 @@ class LiveUpdateEventAppPage(LiveUpdateEventPage):
 
 
 class LiveUpdateEventFocusPage(LiveUpdateEventPage):
+    def __init__(self, focused_update, **kwargs):
+        og_data = {
+            "type": "article",
+            "url": make_event_url(c.liveupdate_event._id),
+            "description": trunc_string(
+                focused_update.body.strip(), MAX_DESCRIPTION_LENGTH),
+            "image": static("liveupdate-logo.png"),
+            "image:width": "300",
+            "image:height": "300",
+            "site_name": g.short_description,
+        }
+
+        LiveUpdateEventPage.__init__(
+            self,
+            og_data=og_data,
+            **kwargs
+        )
+
     def build_toolbars(self):
         return []
 


### PR DESCRIPTION
This should make embeds of links to specific updates more useful.

Example og tags for [a sample update](https://www.reddit.com/live/splatest/updates/a7f63028-4aef-11e6-96f2-06cd44323665).

``` html
<meta property="og:site_name" content="reddit: the front page of the internet">
<meta property="og:description" content="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut quam ipsum, egestas ac odio ac, volutpat imperdiet quam. Praesent ullamcorper dolor...">
<meta property="og:url" content="https://www.reddit.com/live/splatest">
<meta property="og:image" content="//www.redditstatic.com/liveupdate-logo.png">
<meta property="og:image:height" content="300">
<meta property="og:type" content="article">
<meta property="og:image:width" content="300">
```

Stagingify the URL above to see it live.

This has not been tested against the OG debugger or anything due to the annoyances of doing that through proxies.

:eyeglasses: @umbrae @powerlanguage 
