### PR TITLE
Add API endpoint to get the current "happening now" thread

### DIFF
--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -144,6 +144,13 @@ class LiveUpdate(Plugin):
         )
 
         mc(
+            "/live/happening-now",
+            action="happening_now",
+            controller="liveupdateevents",
+            conditions={"function": not_in_sr}
+        )
+
+        mc(
             "/api/live/:action",
             controller="liveupdateevents",
             conditions={"function": not_in_sr},

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -979,6 +979,24 @@ class LiveUpdateEventsController(RedditController):
             page_classes=["liveupdate-home"],
         ).render()
 
+    @require_oauth2_scope("read")
+    @api_doc(
+        section=api_section.live,
+        uri="/live/happening-now",
+    )
+    def GET_happening_now(self):
+        """Redirect to the live thread "happening now".
+
+        "happening now" means it's currently promoted on the frontpage.
+        Will 404 if there is not live thread "happening now".
+        """
+        current_thread_id = NamedGlobals.get(HAPPENING_NOW_KEY, None)
+        if current_thread_id:
+            current_thread = LiveUpdateEvent._byID(current_thread_id)
+            self.redirect(current_thread.url())
+        else:
+            abort(404)
+
     @validate(
         VEmployee(),
         num=VLimit("limit", default=25, max_limit=100),


### PR DESCRIPTION
Adds a API endpoint to get the current promoted live thread and redirect to it. Like GET_sticky, this will 404 if no thread is currently promoted.

Closes reddit/reddit#1654
