### PR TITLE
Fix the documented url for /api/live/happening_now

### DIFF
--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -982,7 +982,7 @@ class LiveUpdateEventsController(RedditController):
     @require_oauth2_scope("read")
     @api_doc(
         section=api_section.live,
-        uri="/live/happening_now",
+        uri="/api/live/happening_now",
     )
     def GET_happening_now(self):
         """ Get some basic information about the currently featured live thread.


### PR DESCRIPTION
Messed up the api doc url >.< 
