### PR TITLE
Fix the way we get ids so that json listings work

### DIFF
--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -242,7 +242,7 @@ class LiveUpdateEventJsonTemplate(ThingJsonTemplate):
         elif attr == "websocket_url":
             if thing.state == "live":
                 return websockets.make_url(
-                    "/live/" + c.liveupdate_event._id, max_age=24 * 60 * 60)
+                    "/live/" + thing._id, max_age=24 * 60 * 60)
             else:
                 return None
         else:


### PR DESCRIPTION
There doesn't seem to be any reason to use the context instead of just using thing._id here, and it's breaking json listings (eg reddit.com/live/active.json), so proposing this fix.
