### PR TITLE
Add oembed info for mobile

### DIFF
--- a/reddit_liveupdate/media_embeds.py
+++ b/reddit_liveupdate/media_embeds.py
@@ -174,13 +174,11 @@ class _LiveEmbedlyScraper(_OEmbedScraper):
         if not thumbnail:
             return None, None, None, None
 
-        secure_oembed = self.fetch_oembed()
-
         return (
             thumbnail,
             preview_object,
             media_object,
-            self.make_media_object(secure_oembed),
+            None,
         )
 
 

--- a/reddit_liveupdate/media_embeds.py
+++ b/reddit_liveupdate/media_embeds.py
@@ -307,7 +307,7 @@ def process_liveupdate_scraper_q():
         payload = {
             "liveupdate_id": "LiveUpdate_" + d['liveupdate_id'],
             "media_embeds": liveupdate.embeds,
-            "mobile_embeds": liveUpdate.mobile_embeds,
+            "mobile_embeds": liveupdate.mobile_embeds,
         }
         send_event_broadcast(d['event_id'],
                              type="embeds_ready",

--- a/reddit_liveupdate/media_embeds.py
+++ b/reddit_liveupdate/media_embeds.py
@@ -13,7 +13,7 @@ from pylons import app_globals as g
 
 from r2.lib import amqp
 from r2.lib.db import tdb_cassandra
-from r2.lib.media import MediaEmbed, Scraper, get_media_embed
+from r2.lib.media import MediaEmbed, Scraper, get_media_embed, _OEmbedScraper
 from r2.lib.utils import sanitize_url, TimeoutFunction, TimeoutFunctionException
 
 from reddit_liveupdate import pages
@@ -60,6 +60,7 @@ def parse_embeds(event_id, liveupdate_id, maxwidth=_EMBED_WIDTH):
 
     urls = _extract_isolated_urls(liveupdate.body)
     liveupdate.media_objects = _scrape_media_objects(urls, maxwidth=maxwidth)
+    liveupdate.mobile_objects = _scrape_mobile_media_objects(urls)
     LiveUpdateStream.add_update(event, liveupdate)
 
     return liveupdate
@@ -78,6 +79,21 @@ def _extract_isolated_urls(md):
         if url and url != "self":
             urls.append(url)
     return urls
+
+
+def _scrape_mobile_media_objects(urls):
+    return filter(None, (_scrape_mobile_media_object(url) for url in urls))
+
+
+def _scrape_mobile_media_object(url):
+    scraper = _LiveEmbedlyScraper(url)
+    try:
+        _, _, result, _ = scraper.scrape()
+        return result['oembed']
+    except:
+        pass
+
+    return None
 
 
 def _scrape_media_objects(urls, autoplay=False, maxwidth=_EMBED_WIDTH, max_urls=3):
@@ -129,6 +145,43 @@ class LiveScraper(Scraper):
 
         return _EmbedlyCardFallbackScraper(url, scraper)
 
+# mostly lifted from the EmbedlyScraper in r2
+class _LiveEmbedlyScraper(_OEmbedScraper):
+    OEMBED_ENDPOINT = "https://api.embed.ly/1/oembed"
+
+    @classmethod
+    def matches(cls, url):
+        return True
+
+    def __init__(self, url):
+        super(_LiveEmbedlyScraper, self).__init__(
+            url,
+            maxwidth=500,
+        )
+
+        self.allowed_oembed_types = {"video", "rich", "link", "photo"}
+        self.oembed_params["key"] = g.embedly_api_key
+
+    def fetch_oembed(self):
+        return super(_LiveEmbedlyScraper, self).fetch_oembed(
+            self.OEMBED_ENDPOINT
+        )
+
+    def scrape(self):
+        scrape_results = super(_LiveEmbedlyScraper, self).scrape()
+        thumbnail, preview_object, media_object, _ = scrape_results
+
+        if not thumbnail:
+            return None, None, None, None
+
+        secure_oembed = self.fetch_oembed()
+
+        return (
+            thumbnail,
+            preview_object,
+            media_object,
+            self.make_media_object(secure_oembed),
+        )
 
 
 class _EmbedlyCardFallbackScraper(Scraper):
@@ -253,12 +306,10 @@ def process_liveupdate_scraper_q():
                 d["event_id"], d["liveupdate_id"], e)
             return
 
-        if not liveupdate.media_objects:
-            return
-
         payload = {
             "liveupdate_id": "LiveUpdate_" + d['liveupdate_id'],
-            "media_embeds": liveupdate.embeds
+            "media_embeds": liveupdate.embeds,
+            "mobile_embeds": liveUpdate.mobile_embeds,
         }
         send_event_broadcast(d['event_id'],
                              type="embeds_ready",

--- a/reddit_liveupdate/models.py
+++ b/reddit_liveupdate/models.py
@@ -165,6 +165,7 @@ class LiveUpdate(object):
         "stricken": False,
         "_spam": False,
         "media_objects": [],
+        "mobile_objects": [],
     }
 
     def __init__(self, id=None, data=None):
@@ -220,6 +221,10 @@ class LiveUpdate(object):
                 pass
         return embeds
 
+    @property
+    def mobile_embeds(self):
+        # can filter these results down here if needed
+        return self.mobile_objects
 
 class LiveUpdateActivityHistoryByEvent(tdb_cassandra.View):
     _use_db = True

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -419,6 +419,7 @@ class LiveUpdateJsonTemplate(ThingJsonTemplate):
         author="author",
         stricken="stricken",
         embeds="embeds",
+        mobile_embeds="mobile_embeds",
     )
 
     def thing_attr(self, thing, attr):


### PR DESCRIPTION
Adding embed info for mobile to the LiveUpdates. Initially I know we thought this was going to cause some issues, however a few things pushed me in this direction.
1) If we don't do this then we will have to fetch embed info for all of the items in the listings... which is a lot.
2) The oembed response is a lot smaller than the extract response and has what we need so should perform well, we were also already using it in the other scraper code.
3) I figured out how to write the scraper code :)
