### PR TITLE
Make mobile scraping simpler

### DIFF
--- a/reddit_liveupdate/media_embeds.py
+++ b/reddit_liveupdate/media_embeds.py
@@ -163,24 +163,18 @@ class _LiveEmbedlyScraper(_OEmbedScraper):
         self.allowed_oembed_types = {"video", "rich", "link", "photo"}
         self.oembed_params["key"] = g.embedly_api_key
 
+    def fetch_media(self):
+        # Don't need this for mobile
+        return None
+
     def fetch_oembed(self):
         return super(_LiveEmbedlyScraper, self).fetch_oembed(
             self.OEMBED_ENDPOINT
         )
 
     def scrape(self):
-        scrape_results = super(_LiveEmbedlyScraper, self).scrape()
-        thumbnail, preview_object, media_object, _ = scrape_results
-
-        if not thumbnail:
-            return None, None, None, None
-
-        return (
-            thumbnail,
-            preview_object,
-            media_object,
-            None,
-        )
+        media_object = self.make_media_object(self.oembed)
+        return None, None, media_object, media_object
 
 
 class _EmbedlyCardFallbackScraper(Scraper):

--- a/reddit_liveupdate/media_embeds.py
+++ b/reddit_liveupdate/media_embeds.py
@@ -173,6 +173,9 @@ class _LiveEmbedlyScraper(_OEmbedScraper):
         )
 
     def scrape(self):
+        if not self.oembed:
+            return None, None, None, None
+
         media_object = self.make_media_object(self.oembed)
         return None, None, media_object, media_object
 

--- a/reddit_liveupdate/media_embeds.py
+++ b/reddit_liveupdate/media_embeds.py
@@ -163,10 +163,6 @@ class _LiveEmbedlyScraper(_OEmbedScraper):
         self.allowed_oembed_types = {"video", "rich", "link", "photo"}
         self.oembed_params["key"] = g.embedly_api_key
 
-    def fetch_media(self):
-        # Don't need this for mobile
-        return None
-
     def fetch_oembed(self):
         return super(_LiveEmbedlyScraper, self).fetch_oembed(
             self.OEMBED_ENDPOINT
@@ -177,7 +173,7 @@ class _LiveEmbedlyScraper(_OEmbedScraper):
             return None, None, None, None
 
         media_object = self.make_media_object(self.oembed)
-        return None, None, media_object, media_object
+        return None, None, media_object, None
 
 
 class _EmbedlyCardFallbackScraper(Scraper):


### PR DESCRIPTION
The purpose of this is to fix scraping of oembed data for urls such as http://www.northwestprintwear.com/WildLifeImprints/kids/large/KDELG.jpg. Embedly doesn't return a thumbnail for these which makes the superclass ignore them, so I simplified the logic to just always return the oembed whether there is a thumbnail or not in the mobile scraping class.