### PR TITLE
Allow caching of the about endpoint.

### DIFF
--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -421,6 +421,7 @@ class LiveUpdateController(RedditController):
         """
         if not is_api():
             self.abort404()
+        response.headers["Cache-Control"] = "max-age=15"
         content = Wrapped(c.liveupdate_event)
         return pages.LiveUpdateEventPage(content=content).render()
 


### PR DESCRIPTION
When a live thread is featured on reddit's homepage, we effectively DDoS
ourselves with requests to both a live thread and the thread's about page. The
about page is only ever modified when the sidebar of said thread is modified
and therefore is safe to cache for short time periods.

👓 @spladug 