### PR TITLE
Fix encoding error with subreddit name

### DIFF
--- a/reddit_liveupdate/scraper.py
+++ b/reddit_liveupdate/scraper.py
@@ -4,6 +4,7 @@ import urlparse
 from pylons import tmpl_context as c
 from pylons import app_globals as g
 
+from r2.lib.filters import _force_utf8
 from r2.lib.hooks import HookRegistrar
 from r2.lib.media import Scraper, MediaEmbed
 from r2.lib.template_helpers import format_html
@@ -43,7 +44,7 @@ class _LiveUpdateScraper(Scraper):
         params = {}
         if c.site:  # play it safe when in a qproc
             if getattr(c.user, "pref_show_stylesheets", True):
-                params["stylesr"] = c.site.name
+                params["stylesr"] = _force_utf8(c.site.name)
 
         url = urlparse.urlunparse((
             None,

--- a/reddit_liveupdate/scraper.py
+++ b/reddit_liveupdate/scraper.py
@@ -4,11 +4,11 @@ import urlparse
 from pylons import tmpl_context as c
 from pylons import app_globals as g
 
-from r2.lib.filters import _force_utf8
 from r2.lib.hooks import HookRegistrar
 from r2.lib.media import Scraper, MediaEmbed
 from r2.lib.template_helpers import format_html
 from r2.lib.utils import UrlParser
+from r2.models.subreddit import FakeSubreddit
 
 
 hooks = HookRegistrar()
@@ -43,8 +43,9 @@ class _LiveUpdateScraper(Scraper):
 
         params = {}
         if c.site:  # play it safe when in a qproc
-            if getattr(c.user, "pref_show_stylesheets", True):
-                params["stylesr"] = _force_utf8(c.site.name)
+            if (getattr(c.user, "pref_show_stylesheets", True) and
+                    not isinstance(c.site, FakeSubreddit)):
+                params["stylesr"] = c.site.name
 
         url = urlparse.urlunparse((
             None,


### PR DESCRIPTION
:eyeglasses: @bsimpson63, @madbook 

I don't know why these errors just started happening (can't see any commits around this time)

```
In [7]: urllib.urlencode({'stylesr': u'all(filtré)'})
---------------------------------------------------------------------------
UnicodeEncodeError                        Traceback (most recent call last)
<ipython-input-7-831828e28b81> in <module>()
----> 1 urllib.urlencode({'stylesr': a})

/usr/lib/python2.7/urllib.pyc in urlencode(query, doseq)
   1330         for k, v in query:
   1331             k = quote_plus(str(k))
-> 1332             v = quote_plus(str(v))
   1333             l.append(k + '=' + v)
   1334     else:

UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 9: ordinal not in range(128)

In [9]: urllib.urlencode({'stylesr': _force_utf8(u'all(filtré)')})
Out[9]: 'stylesr=all%28filtr%C3%A9%29'

```

Fixes this bug that started happening in the last hour (due to `u'all(filtré)'`) :
```
listing E: UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 14: ordinal not in range(128) FP: /r/all?after=t3_5i44w1
```