### PR TITLE
Add API method to get live updates by id

### DIFF
--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -136,6 +136,12 @@ class LiveUpdate(Plugin):
         )
 
         mc(
+            "/api/live/by_id/:names",
+            action="listing",
+            controller="liveupdatebyid",
+        )
+
+        mc(
             "/live/:filter",
             action="listing",
             controller="liveupdateevents",
@@ -203,6 +209,7 @@ class LiveUpdate(Plugin):
 
         from reddit_liveupdate.controllers import (
             controller_hooks,
+            LiveUpdateByIDController,
             LiveUpdateController,
             LiveUpdateEventsController,
             LiveUpdatePixelController,
@@ -234,7 +241,9 @@ class LiveUpdate(Plugin):
         from reddit_liveupdate.controllers import (
             LiveUpdateController,
             LiveUpdateEventsController,
+            LiveUpdateByIDController,
         )
 
         yield LiveUpdateController, "/api/live/{thread}"
         yield LiveUpdateEventsController, ""
+        yield LiveUpdateByIDController, ""

--- a/reddit_liveupdate/validators.py
+++ b/reddit_liveupdate/validators.py
@@ -20,12 +20,33 @@ from reddit_liveupdate.permissions import ContributorPermissionSet
 
 
 class VLiveUpdateEvent(Validator):
+    splitter = re.compile('[ ,]+')
+
+    def __init__(self, param, multiple=False, **kw):
+        self.multiple = multiple
+        Validator.__init__(self, param, kw)
+
+    def param_docs(self):
+        if self.multiple:
+            return {
+                self.param: ("A comma-separated list of ids"),
+            }
+        else:
+            return {
+                self.param: ("A live update event id"),
+            }
+
     def run(self, id):
+
         if not id:
             return None
 
         try:
-            return models.LiveUpdateEvent._byID(id)
+            if self.multiple:
+                items = self.splitter.split(id)
+            else:
+                items = id
+            return models.LiveUpdateEvent._byID(items)
         except tdb_cassandra.NotFound:
             return None
 


### PR DESCRIPTION
This will allow us to efficiently fetch multiple live events at a time from the gateway for displaying in carousels or banners.