### PR TITLE
Add job that closes abandoned threads

### DIFF
--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -113,6 +113,16 @@ def _broadcast(type, payload):
     send_event_broadcast(c.liveupdate_event._id, type, payload)
 
 
+def close_event(event):
+    """Close a liveupdate event"""
+    event.state = "complete"
+    event._commit()
+
+    queries.complete_event(event)
+
+    send_event_broadcast(event._id, type="complete", payload={})
+
+
 class LiveUpdateBuilder(QueryBuilder):
     def wrap_items(self, items):
         wrapped = []
@@ -877,12 +887,7 @@ class LiveUpdateController(RedditController):
         Requires the `close` permission for this thread.
 
         """
-        c.liveupdate_event.state = "complete"
-        c.liveupdate_event._commit()
-
-        queries.complete_event(c.liveupdate_event)
-
-        _broadcast(type="complete", payload={})
+        close_event(c.liveupdate_event)
         liveupdate_events.close_event(context=c, request=request)
 
         form.refresh()

--- a/reddit_liveupdate/housekeeping.py
+++ b/reddit_liveupdate/housekeeping.py
@@ -5,6 +5,7 @@ import pytz
 from pylons import app_globals as g
 from pycassa.cassandra.ttypes import NotFoundException
 
+from reddit_liveupdate.controllers import close_event
 from reddit_liveupdate.models import LiveUpdateEvent, LiveUpdateStream
 
 
@@ -40,5 +41,4 @@ def close_abandoned_threads():
 
         if event_last_modified < horizon:
             g.log.warning("Closing %s for inactivity.", event._id)
-            event.state = "complete"
-            event._commit()
+            close_event(event)

--- a/reddit_liveupdate/housekeeping.py
+++ b/reddit_liveupdate/housekeeping.py
@@ -1,0 +1,44 @@
+import datetime
+
+import pytz
+
+from pylons import app_globals as g
+from pycassa.cassandra.ttypes import NotFoundException
+
+from reddit_liveupdate.models import LiveUpdateEvent, LiveUpdateStream
+
+
+# how long a live thread must go without being updated before we consider it
+# abandoned and eligible to be automatically closed.
+DERELICTION_THRESHOLD = datetime.timedelta(days=7)
+
+
+def close_abandoned_threads():
+    """Find live threads that are abandoned and close them.
+
+    Jobs like the activity tracker iterate through all open live threads, so
+    closing abandoned threads removes some effort from them and is generally
+    good for cleanliness.
+
+    """
+    now = datetime.datetime.now(pytz.UTC)
+    horizon = now - DERELICTION_THRESHOLD
+
+    for event in LiveUpdateEvent._all():
+        if event.state != "live" or event.banned:
+            continue
+
+        try:
+            columns = LiveUpdateStream._cf.get(
+                event._id, column_reversed=True, column_count=1)
+        except NotFoundException:
+            event_last_modified = event._date
+        else:
+            updates = LiveUpdateStream._column_to_obj([columns])
+            most_recent_update = updates.pop()
+            event_last_modified = most_recent_update._date
+
+        if event_last_modified < horizon:
+            g.log.warning("Closing %s for inactivity.", event._id)
+            event.state = "complete"
+            event._commit()

--- a/upstart/reddit-job-liveupdate_close_abandoned_threads.conf
+++ b/upstart/reddit-job-liveupdate_close_abandoned_threads.conf
@@ -1,0 +1,12 @@
+description "close threads that have not been updated in a while"
+
+task
+manual
+stop on reddit-stop or runlevel [016]
+
+nice 10
+
+script
+    . /etc/default/reddit
+    wrap-job paster run $REDDIT_INI -c 'from reddit_liveupdate import housekeeping; housekeeping.close_abandoned_threads()'
+end script


### PR DESCRIPTION
Jobs like the activity tracker iterate through all currently-live
threads. To keep them quick, we close out live threads that have not
been updated in over a week.

:eyeglasses: @rram @bsimpson63 