### PR TITLE
Fix some consistency bugs in embed processing

### DIFF
--- a/reddit_liveupdate/media_embeds.py
+++ b/reddit_liveupdate/media_embeds.py
@@ -301,6 +301,9 @@ def process_liveupdate_scraper_q():
         if not liveupdate:
             return
 
+        if not liveupdate.embeds and not liveupdate.mobile_embeds:
+            return
+
         payload = {
             "liveupdate_id": "LiveUpdate_" + d['liveupdate_id'],
             "media_embeds": liveupdate.embeds,

--- a/reddit_liveupdate/media_embeds.py
+++ b/reddit_liveupdate/media_embeds.py
@@ -51,8 +51,10 @@ def parse_embeds(event_id, liveupdate_id, maxwidth=_EMBED_WIDTH):
         liveupdate_id = uuid.UUID(liveupdate_id)
 
     try:
-        event = LiveUpdateEvent._byID(event_id)
-        liveupdate = LiveUpdateStream.get_update(event, liveupdate_id)
+        event = LiveUpdateEvent._byID(
+            event_id, read_consistency_level=tdb_cassandra.CL.QUORUM)
+        liveupdate = LiveUpdateStream.get_update(
+            event, liveupdate_id, read_consistency_level=tdb_cassandra.CL.QUORUM)
     except tdb_cassandra.NotFound:
         g.log.warning("Couldn't find event/liveupdate for embedding: %r / %r",
                       event_id, liveupdate_id)

--- a/reddit_liveupdate/media_embeds.py
+++ b/reddit_liveupdate/media_embeds.py
@@ -298,6 +298,9 @@ def process_liveupdate_scraper_q():
                 d["event_id"], d["liveupdate_id"], e)
             return
 
+        if not liveupdate:
+            return
+
         payload = {
             "liveupdate_id": "LiveUpdate_" + d['liveupdate_id'],
             "media_embeds": liveupdate.embeds,

--- a/reddit_liveupdate/models.py
+++ b/reddit_liveupdate/models.py
@@ -135,8 +135,9 @@ class LiveUpdateStream(tdb_cassandra.View):
         cls._set_values(event._id, columns)
 
     @classmethod
-    def get_update(cls, event, id):
-        thing = cls._byID(event._id, properties=[id])
+    def get_update(cls, event, id, read_consistency_level=None):
+        thing = cls._byID(event._id, properties=[id],
+                          read_consistency_level=read_consistency_level)
 
         try:
             data = thing._t[id]


### PR DESCRIPTION
This fixes some issues with the liveupdate_scraper_q (should address the root cause of #159).

This relies on a change to tdb_cassandra over in r2 core.

See commit messages for further explanation of individual changes.