### PR TITLE
Hook up some AMQP messages for important actions

### DIFF
--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -237,6 +237,10 @@ class LiveUpdate(Plugin):
             "liveupdate_scraper_q": MessageQueue(bind_to_self=True),
         })
 
+        queues.liveupdate_scraper_q << (
+            "new_liveupdate_update",
+        )
+
     source_root_url = "https://github.com/reddit/reddit-plugin-liveupdate/blob/master/reddit_liveupdate/"
     def get_documented_controllers(self):
         from reddit_liveupdate.controllers import (

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -987,7 +987,7 @@ class LiveUpdateController(RedditController):
 
 class LiveUpdateEventBuilder(IDBuilder):
     def thing_lookup(self, names):
-        return LiveUpdateEvent._byID(names, return_dict=False)
+        return LiveUpdateEvent._by_fullname(names, return_dict=False)
 
     def wrap_items(self, items):
         return [self.wrap(item) for item in items]

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -1,5 +1,6 @@
 import collections
 import hashlib
+import json
 import os
 import uuid
 
@@ -61,14 +62,11 @@ from r2.models.admintools import send_system_message
 from r2.lib.errors import errors
 from r2.lib.utils import url_links_builder
 from r2.lib.pages import AdminPage, PaneStack, Wrapped, RedditError, Reddit
-from r2.lib import geoip
+from r2.lib import amqp, geoip
 
 from reddit_liveupdate import pages, queries
 from reddit_liveupdate.contrib import iso3166
-from reddit_liveupdate.media_embeds import (
-    get_live_media_embed,
-    queue_parse_embeds,
-)
+from reddit_liveupdate.media_embeds import get_live_media_embed
 from reddit_liveupdate.models import (
     InviteNotFoundError,
     LiveUpdate,
@@ -509,6 +507,11 @@ class LiveUpdateController(RedditController):
         c.liveupdate_event.nsfw = nsfw
         c.liveupdate_event._commit()
 
+        amqp.add_item("liveupdate_event_edited", json.dumps({
+            "event_fullname": c.liveupdate_event._fullname,
+            "editor_fullname": c.user._fullname,
+        }))
+
         form.set_html(".status", _("saved"))
         form.refresh()
 
@@ -613,6 +616,12 @@ class LiveUpdateController(RedditController):
                 "url": "/live/" + c.liveupdate_event._id,
             },
         )
+
+        amqp.add_item("new_liveupdate_contributor", json.dumps({
+            "event_fullname": c.liveupdate_event._fullname,
+            "inviter_fullname": c.user._fullname,
+            "invitee_fullname": user._fullname,
+        }))
 
         # add the user to the table
         contributor = LiveUpdateContributor(user, permissions)
@@ -804,8 +813,12 @@ class LiveUpdateController(RedditController):
         rendered = wrapped.render(style="api")
         _broadcast(type="update", payload=rendered)
 
-        # Queue up parsing any embeds
-        queue_parse_embeds(c.liveupdate_event, update)
+        amqp.add_item("new_liveupdate_update", json.dumps({
+            "event_fullname": c.liveupdate_event._fullname,
+            "author_fullname": c.user._fullname,
+            "liveupdate_id": str(update._id),
+            "body": text,
+        }))
 
         liveupdate_events.update_event(update, context=c, request=request)
 
@@ -923,6 +936,12 @@ class LiveUpdateController(RedditController):
         liveupdate_events.report_event(
             report_type, context=c, request=request
         )
+
+        amqp.add_item("new_liveupdate_report", json.dumps({
+            "event_fullname": c.liveupdate_event._fullname,
+            "reporter_fullname": c.user._fullname,
+            "reason": report_type,
+        }))
 
         try:
             default_subreddit = Subreddit._by_name(g.default_sr)
@@ -1135,6 +1154,11 @@ class LiveUpdateEventsController(RedditController):
         )
         event.add_contributor(c.user, ContributorPermissionSet.SUPERUSER)
         queries.create_event(event)
+
+        amqp.add_item("new_liveupdate_event", json.dumps({
+            "event_fullname": event._fullname,
+            "creator_fullname": c.user._fullname,
+        }))
 
         form.redirect("/live/" + event._id)
         form._send_data(id=event._id)

--- a/reddit_liveupdate/media_embeds.py
+++ b/reddit_liveupdate/media_embeds.py
@@ -32,14 +32,6 @@ def get_live_media_embed(media_object):
     return get_media_embed(media_object)
 
 
-def queue_parse_embeds(event, liveupdate):
-    msg = json.dumps({
-        'liveupdate_id': unicode(liveupdate._id),  # serializing UUID
-        'event_id': event._id,  # Already a string
-    })
-    amqp.add_item('liveupdate_scraper_q', msg)
-
-
 def parse_embeds(event_id, liveupdate_id, maxwidth=_EMBED_WIDTH):
     """Find, scrape, and store any embeddable URLs in this liveupdate.
 
@@ -286,24 +278,28 @@ def process_liveupdate_scraper_q():
     def _handle_q(msg):
         d = json.loads(msg.body)
 
+        print d
+        event_id = d.get("event_id") or d["event_fullname"][len("LiveUpdateEvent_"):]
+        liveupdate_id = d["liveupdate_id"]
+
         try:
             fn = TimeoutFunction(parse_embeds, 10)
-            liveupdate = fn(d['event_id'], d['liveupdate_id'])
+            liveupdate = fn(event_id, liveupdate_id)
         except TimeoutFunctionException:
             g.log.warning(
-                "Timed out on %s::%s", d["event_id"], d["liveupdate_id"])
+                "Timed out on %s::%s", event_id, liveupdate_id)
             return
         except Exception as e:
             g.log.warning("Failed to scrape %s::%s: %r",
-                d["event_id"], d["liveupdate_id"], e)
+                event_id, liveupdate_id, e)
             return
 
         payload = {
-            "liveupdate_id": "LiveUpdate_" + d['liveupdate_id'],
+            "liveupdate_id": "LiveUpdate_" + liveupdate_id,
             "media_embeds": liveupdate.embeds,
             "mobile_embeds": liveupdate.mobile_embeds,
         }
-        send_event_broadcast(d['event_id'],
+        send_event_broadcast(event_id,
                              type="embeds_ready",
                              payload=payload)
 

--- a/reddit_liveupdate/media_embeds.py
+++ b/reddit_liveupdate/media_embeds.py
@@ -278,7 +278,6 @@ def process_liveupdate_scraper_q():
     def _handle_q(msg):
         d = json.loads(msg.body)
 
-        print d
         event_id = d.get("event_id") or d["event_fullname"][len("LiveUpdateEvent_"):]
         liveupdate_id = d["liveupdate_id"]
 

--- a/reddit_liveupdate/models.py
+++ b/reddit_liveupdate/models.py
@@ -63,10 +63,6 @@ class LiveUpdateEvent(tdb_cassandra.Thing):
         return ContributorPermissionSet.loads(permission_string)
 
     @property
-    def _fullname(self):
-        return self._id
-
-    @property
     def _id36(self):
         # this is a bit of a hack but lets us use events in denormalizedrels
         return self._id

--- a/scripts/backfill/recompute_fullnames.py
+++ b/scripts/backfill/recompute_fullnames.py
@@ -1,0 +1,48 @@
+import collections
+
+from pycassa.columnfamily import gm_timestamp
+
+from r2.models.query_cache import CachedQueryMutator, MAX_CACHED_ITEMS
+
+from reddit_liveupdate import models, queries
+
+
+def recompute_listings():
+    # when removing the _fullname override from LiveUpdateEvent, the format of
+    # event fullnames changed. this recomputes the static listings so that they
+    # contain appropriate data going forward.
+    #
+    # this does not do anything to the active or reported listings. in the
+    # prior case, we assume it will be regenerated properly one minute from
+    # now. in the latter case, humans should ensure that the listing is empty
+    # of reports before running this job.
+
+    items_by_state = collections.defaultdict(list)
+    queries_by_state = {
+        "live": queries.get_live_events,
+        "complete": queries.get_complete_events,
+    }
+
+    for event in models.LiveUpdateEvent._all():
+        items_by_state[event.state].append(event)
+
+    timestamp = gm_timestamp()
+    with CachedQueryMutator() as m:
+        for state, query_fn in queries_by_state.iteritems():
+            query = query_fn("new", "all")
+
+            items = items_by_state[state]
+            sorted_items = sorted(items, key=lambda ev: ev._date, reverse=True)
+            listing = [item for item in sorted_items][:MAX_CACHED_ITEMS]
+            cols = query._cols_from_things(listing)
+
+            query._raw_replace(
+                mutator=m,
+                cols=cols,
+                ttl=None,
+                job_timestamp=timestamp,
+                clobber=True,
+            )
+
+
+recompute_listings()


### PR DESCRIPTION
I reorganized the scraper stuff to take advantage of this newly generalized "update was posted" message. I've tried to make the payloads make sense in and of themselves, but please let me know if I should change them to fit other standards better.