### PR TITLE
Allow users with "close" permission to see settings page

### DIFF
--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -460,10 +460,11 @@ class LiveUpdateController(RedditController):
             content=listing,
         ).render()
 
-    @validate(
-        VLiveUpdateContributorWithPermission("settings"),
-    )
     def GET_edit(self):
+        if not (c.liveupdate_permissions.allow("settings") or
+                c.liveupdate_permissions.allow("close")):
+            abort(403)
+
         return pages.LiveUpdateEventPage(
             content=pages.LiveUpdateEventConfiguration(),
         ).render()

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -124,7 +124,8 @@ class LiveUpdateEventPage(LiveUpdatePage):
                 ),
             ]
 
-            if c.liveupdate_permissions.allow("settings"):
+            if (c.liveupdate_permissions.allow("settings") or
+                    c.liveupdate_permissions.allow("close")):
                 tabs.append(NavButton(
                     _("settings"),
                     "/edit",

--- a/reddit_liveupdate/templates/liveupdateeventconfiguration.html
+++ b/reddit_liveupdate/templates/liveupdateeventconfiguration.html
@@ -4,6 +4,7 @@
 <%namespace name="utils" file="utils.html"/>
 <%namespace name="liveupdate_utils" file="liveupdateutils.html" />
 
+% if c.liveupdate_permissions.allow("settings"):
 <%liveupdate_utils:configuration_form button_name="${_('save settings')}" endpoint="live/${c.liveupdate_event._id}/edit" thing="${c.liveupdate_event}">
   <%utils:line_field title="${_('resources')}" description="${_('information and links that are useful at any point')}">
     ${UserText(None, text=getattr(c.liveupdate_event, 'resources', ''), editable=True, creating=True, name="resources", have_form=False)}
@@ -21,6 +22,7 @@
     </label>
   </%utils:line_field>
 </%liveupdate_utils:configuration_form>
+% endif
 
 % if c.liveupdate_permissions.allow("close"):
 <%utils:line_field title="${_('close the live thread')}" css_class="danger-zone">


### PR DESCRIPTION
Previously, users with the "close" permission but not the "settings"
permission could not see the page that had the close button. This allows
the user to access that page but not see the form that is unusable to
them.

This fixes #114.