### PR TITLE
Add listing of threads the current user is a contributor to

### DIFF
--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -147,7 +147,7 @@ class LiveUpdate(Plugin):
             action="listing",
             controller="liveupdateevents",
             conditions={"function": not_in_sr},
-            requirements={"filter": "open|closed|reported|active"},
+            requirements={"filter": "open|closed|reported|active|happening_now"},
         )
 
         mc(
@@ -216,6 +216,7 @@ class LiveUpdate(Plugin):
         api('liveupdatefocusapp', pages.LiveUpdateEventAppJsonTemplate)
         api('liveupdateevent', pages.LiveUpdateEventJsonTemplate)
         api('liveupdatereportedeventrow', pages.LiveUpdateEventJsonTemplate)
+        api('liveupdatefeaturedevent', pages.LiveUpdateFeaturedEventJsonTemplate)
         api('liveupdate', pages.LiveUpdateJsonTemplate)
         api('liveupdatecontributortableitem',
             pages.ContributorTableItemJsonTemplate)

--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -147,7 +147,7 @@ class LiveUpdate(Plugin):
             action="listing",
             controller="liveupdateevents",
             conditions={"function": not_in_sr},
-            requirements={"filter": "open|closed|reported|active|happening_now"},
+            requirements={"filter": "open|closed|reported|active|happening_now|mine"},
         )
 
         mc(

--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -151,16 +151,10 @@ class LiveUpdate(Plugin):
         )
 
         mc(
-            '/api/live/happening_now',
-            controller='liveupdateevents',
-            action='happening_now',
-        )
-
-        mc(
             "/api/live/:action",
             controller="liveupdateevents",
             conditions={"function": not_in_sr},
-            requirements={"action": "create"},
+            requirements={"action": "create|happening_now"},
         )
 
         mc("/live/:event", controller="liveupdate", action="listing",

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -1054,7 +1054,7 @@ class LiveUpdateEventsController(RedditController):
         builder_cls = LiveUpdateEventBuilder
         wrapper = Wrapped
         listing_cls = Listing
-        require_employee = True
+        require_employee = True  # for grepping: this is used like VEmployee
 
         if filter == "open":
             title = _("live threads")

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -9,7 +9,6 @@ from pylons import app_globals as g
 from pylons.i18n import _
 from thrift.transport.TTransport import TTransportException
 
-from r2.config import feature
 from r2.config.extensions import is_api
 from r2.controllers import add_controller
 from r2.controllers.api_docs import api_doc, api_section
@@ -1013,7 +1012,7 @@ class LiveUpdateEventsController(RedditController):
             See also: [/api/live/*thread*/about](#GET_api_live_{thread}_about).
         """
 
-        if not is_api() or not feature.is_enabled('live_happening_now'):
+        if not is_api():
             self.abort404()
 
         featured_event = get_featured_event()
@@ -1269,9 +1268,6 @@ def get_featured_event():
 @controller_hooks.on("hot.get_content")
 def add_featured_live_thread(controller):
     """If we have a live thread featured, display it on the homepage."""
-    if not feature.is_enabled('live_happening_now'):
-        return None
-
     # Not on front page
     if not isinstance(c.site, DefaultSR):
         return None

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -54,12 +54,19 @@ class LiveUpdatePage(Reddit):
 
 class LiveUpdateMetaPage(LiveUpdatePage):
     def build_toolbars(self):
+        tabs = [
+            NavButton(
+                _("reddit live"),
+                "/",
+            ),
+            NavButton(
+                _("happening now"),
+                "/happening_now",
+            ),
+        ]
+
         if c.user_is_loggedin and c.user.employee:
-            tabs = [
-                NavButton(
-                    _("reddit live"),
-                    "/",
-                ),
+            tabs.extend([
                 NavButton(
                     _("active"),
                     "/active",
@@ -72,7 +79,7 @@ class LiveUpdateMetaPage(LiveUpdatePage):
                     _("closed"),
                     "/closed",
                 ),
-            ]
+            ])
 
             if c.user_is_admin:
                 tabs.extend([
@@ -82,13 +89,11 @@ class LiveUpdateMetaPage(LiveUpdatePage):
                     ),
                 ])
 
-            return [NavMenu(
-                tabs,
-                base_path="/live/",
-                type="tabmenu",
-            )]
-        else:
-            return []
+        return [NavMenu(
+            tabs,
+            base_path="/live/",
+            type="tabmenu",
+        )]
 
 
 class LiveUpdateEventPage(LiveUpdatePage):

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -252,6 +252,17 @@ class LiveUpdateEventJsonTemplate(ThingJsonTemplate):
         return "LiveUpdateEvent"
 
 
+class LiveUpdateFeaturedEventJsonTemplate(LiveUpdateEventJsonTemplate):
+    _data_attrs_ = LiveUpdateEventJsonTemplate.data_attrs(
+        featured_in="featured_in",
+    )
+
+    def thing_attr(self, thing, attr):
+        if attr == "featured_in":
+            return list(thing.featured_in)
+        return LiveUpdateEventJsonTemplate.thing_attr(self, thing, attr)
+
+
 REPORT_TYPES = collections.OrderedDict((
     ("spam", N_("spam")),
     ("vote-manipulation", N_("vote manipulation")),
@@ -533,6 +544,10 @@ class LiveUpdateReportedEventRow(Wrapped):
     def report_counts(self):
         for report_type in REPORT_TYPES:
             yield self.reports_by_type[report_type]
+
+
+class LiveUpdateFeaturedEvent(Wrapped):
+    pass
 
 
 def liveupdate_add_props(user, wrapped):

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -65,6 +65,14 @@ class LiveUpdateMetaPage(LiveUpdatePage):
             ),
         ]
 
+        if c.user_is_loggedin:
+            tabs.extend((
+                NavButton(
+                    _("my live threads"),
+                    "/mine",
+                ),
+            ))
+
         if c.user_is_loggedin and c.user.employee:
             tabs.extend([
                 NavButton(

--- a/reddit_liveupdate/public/static/css/liveupdate.less
+++ b/reddit_liveupdate/public/static/css/liveupdate.less
@@ -802,7 +802,7 @@ aside.sidebar {
     }
 
     .tagline {
-        span {
+        > * {
             margin-right: .5em;
         }
 
@@ -816,17 +816,19 @@ aside.sidebar {
             color: red;
         }
 
-        span:after {
+        > *:after {
             content: "–";
             margin-left: .5em;
         }
+
+        > :last-child:after {
+            content: "";
+        }
+
         .admin-buttons {
             display: inline;
             margin-left: .5em;
 
-            span:after {
-                content: "";
-            }
             button {
                 padding: 0;
                 border: none;

--- a/reddit_liveupdate/queries.py
+++ b/reddit_liveupdate/queries.py
@@ -64,3 +64,18 @@ def unreport_event(event):
 
     with CachedQueryMutator() as m:
         m.delete(query, [_LiveUpdateEventReport(event)])
+
+
+@cached_query(LiveUpdateQueryCache)
+def get_contributor_events(user):
+    return FakeQuery(sort=[desc("date")])
+
+
+def add_contributor(event, user):
+    with CachedQueryMutator() as m:
+        m.insert(get_contributor_events(user), [event])
+
+
+def remove_contributor(event, user):
+    with CachedQueryMutator() as m:
+        m.delete(get_contributor_events(user), [event])

--- a/reddit_liveupdate/templates/liveupdateevent.html
+++ b/reddit_liveupdate/templates/liveupdateevent.html
@@ -5,6 +5,7 @@
     <a href="/live/${thing._id}">${thing.title}</a>
   </div>
   <div class="tagline">
+    <%block name="tagline">
     % if thing.state == "live":
       <span class="state">${_("live")}</span>
     % endif
@@ -31,5 +32,6 @@
       % endif
       </div>
     % endif
+    </%block>
   </div>
 </div>

--- a/reddit_liveupdate/templates/liveupdatefeaturedevent.html
+++ b/reddit_liveupdate/templates/liveupdatefeaturedevent.html
@@ -1,0 +1,6 @@
+<%inherit file="liveupdateevent.html" />
+
+<%block name="tagline">
+  ${parent.tagline()}
+  <span>${_("featured in: %(locations)s") % dict(locations=", ".join(thing.featured_in))}</span>
+</%block>

--- a/scripts/backfill/contributor_listings.py
+++ b/scripts/backfill/contributor_listings.py
@@ -1,0 +1,19 @@
+from r2.models.query_cache import CachedQueryMutator
+
+from reddit_liveupdate import models, queries
+
+
+def backfill_listings():
+    events = models.LiveUpdateEvent._all()
+
+    with CachedQueryMutator() as m:
+        for event in events:
+            for contributor_id in event.contributors.iterkeys():
+                m.insert(queries.get_contributor_events(contributor_id), [event])
+
+            invites = models.LiveUpdateContributorInvitesByEvent.get_all(event)
+            for invitee_id in invites.iterkeys():
+                m.insert(queries.get_contributor_events(invitee_id), [event])
+
+
+backfill_listings()


### PR DESCRIPTION
This shows up at /live/mine and allows the user to see which threads
they contribute to or have been invited to contribute to.

The backend storage is set up so we can show a given user's live
threads, but there's no UI yet.

This fixes #91.

(All but the last commit are from #162 which is a prereq for this -- only the latest commit needs distinct review)