### PR TITLE
Allow focus endpoint to be accessed from OAuth2

### DIFF
--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -386,7 +386,13 @@ class LiveUpdateController(RedditController):
 
             return embed_page.render()
 
+    @require_oauth2_scope("read")
+    @api_doc(
+        section=api_section.live,
+        uri="/live/{thread}/updates/{update_id}",
+    )
     def GET_focus(self, target):
+        """Get details about a specific update in a live thread."""
         try:
             target = uuid.UUID(target)
         except (TypeError, ValueError):


### PR DESCRIPTION
The /live/{event}/updates/{event_id} endpoint was added a while ago but
oauth support was left out by accident. This grants access to the "read"
scope and adds it to the API docs.

This fixes #153.