### PR TITLE
Allow embeds to go full screen

### DIFF
--- a/reddit_liveupdate/public/static/js/liveupdate/embeds.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/embeds.js
@@ -54,6 +54,7 @@
           'height': embed.height || 200,
           'scrolling': 'no',
           'frameborder': 0,
+          'allowfullscreen': true,
         })
         r.debug('Rendering embed for link: ', embed.url)
         $placeholder.replaceWith(iframe)


### PR DESCRIPTION
Useful for e.g. youtube videos.

This fixes #116.