### PR TITLE
Add view counts integration for live threads

### DIFF
--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -33,7 +33,10 @@ will be in text frames containing a JSON object with two keys: `type` and
 See /r/live for more information.
 
 """
+import datetime
 import sys
+
+import pytz
 
 from pylons.i18n import N_
 
@@ -63,6 +66,10 @@ class MomentTranslations(LocaleSpecificSource):
         return localized_source
 
 
+def Date(text):
+    return datetime.datetime.strptime(text, "%Y-%m-%d").replace(tzinfo=pytz.utc)
+
+
 class LiveUpdate(Plugin):
     needs_static_build = True
 
@@ -85,6 +92,10 @@ class LiveUpdate(Plugin):
 
         ConfigValue.str: [
             "liveupdate_pixel_domain",
+        ],
+
+        ConfigValue.baseplate(Date): [
+            "liveupdate_min_date_viewcounts",
         ],
     }
 

--- a/reddit_liveupdate/pages.py
+++ b/reddit_liveupdate/pages.py
@@ -225,6 +225,7 @@ class LiveUpdateEventJsonTemplate(ThingJsonTemplate):
         state="state",
         viewer_count="viewer_count",
         viewer_count_fuzzed="viewer_count_fuzzed",
+        total_views="total_views",
         title="title",
         nsfw="nsfw",
         description="description",
@@ -247,6 +248,12 @@ class LiveUpdateEventJsonTemplate(ThingJsonTemplate):
                 return thing.active_visitors_fuzzed
             else:
                 return None
+        elif attr == "total_views":
+            # this requires an extra query, so we'll only show it in places
+            # where we're just getting one event.
+            if not hasattr(thing, "total_views"):
+                return None
+            return thing.total_views
         elif attr == "description_html":
             return filters.spaceCompress(
                 filters.safemarkdown(thing.description, nofollow=True) or "")

--- a/reddit_liveupdate/public/static/js/liveupdate/init.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/init.js
@@ -78,6 +78,7 @@
           this.event.set({
             'viewer_count': message.count,
             'viewer_count_fuzzed': message.fuzzed,
+            'total_views': message.total_views,
           })
         },
         'message:settings': function(updates) {

--- a/reddit_liveupdate/public/static/js/liveupdate/statusBar.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/statusBar.js
@@ -39,6 +39,7 @@
         'change:state change:delay_remaining': this.renderState,
         'change:socket_state': this.onSocketStateChange,
         'change:state change:viewer_count': this.renderViewerCount,
+        'change:total_views': this.renderTotalViews,
       })
     },
 
@@ -129,7 +130,36 @@
 
       if (!this.$viewerCount) {
         this.$viewerCount = $viewerCount
-        this.$el.append($viewerCount)
+        this.$el.find('.state').after($viewerCount)
+      }
+
+      return this
+    },
+
+    renderTotalViews: function() {
+      var $totalViews = this.$totalViews || $('<p class="total-views">')
+      var totalViews = this.model.get('total_views')
+
+      if (totalViews === null) {
+        $totalViews.remove()
+        return
+      }
+
+      if (totalViews < 999) {
+        var formattedTotalViews = totalViews
+      } else if (totalViews <= 999999) {
+        var formattedTotalViews = (totalViews / 1000).toFixed(1) + 'k'
+      } else {
+        var formattedTotalViews = (totalViews / 1000000).toFixed(2) + 'm'
+      }
+
+      var totalViewsString = r.P_('%(num)s view', '%(num)s views', totalViews)
+      $totalViews
+        .text(totalViewsString.format({num: formattedTotalViews}))
+
+      if (!this.$totalViews) {
+        this.$totalViews = $totalViews
+        this.$el.append($totalViews)
       }
 
       return this

--- a/reddit_liveupdate/public/static/js/liveupdate/statusBar.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/statusBar.js
@@ -30,6 +30,20 @@
     },
   })
 
+  function formatTotalViews(totalViews) {
+    var totalViewsString = r.P_('%(num)s total view', '%(num)s total views', totalViews)
+
+    if (totalViews < 999) {
+      var formattedTotalViews = totalViews
+    } else if (totalViews <= 999999) {
+      var formattedTotalViews = (totalViews / 1000).toFixed(1) + 'k'
+    } else {
+      var formattedTotalViews = (totalViews / 1000000).toFixed(2) + 'm'
+    }
+
+    return totalViewsString.format({num: formattedTotalViews})
+  }
+
   exports.StatusBarView = Backbone.View.extend({
     tagName: 'div',
     className: 'status-bar',
@@ -38,8 +52,7 @@
       this.listenTo(this.model, {
         'change:state change:delay_remaining': this.renderState,
         'change:socket_state': this.onSocketStateChange,
-        'change:state change:viewer_count': this.renderViewerCount,
-        'change:total_views': this.renderTotalViews,
+        'change:state change:viewer_count change:total_views': this.renderViewerCount,
       })
     },
 
@@ -117,49 +130,33 @@
     renderViewerCount: function() {
       var $viewerCount = this.$viewerCount || $('<p class="viewer-count">')
 
-      if (this.model.get('state') == 'complete') {
-        $viewerCount.remove();
-        return;
+      var totalViews = this.model.get('total_views')
+
+      if (this.model.get('state') == 'live') {
+        var viewerCount = this.model.get('viewer_count')
+        var viewerString = r.P_('%(num)s viewer', '%(num)s viewers', viewerCount)
+
+        $viewerCount
+          .text(viewerString.format({num: viewerCount}))
+
+        if (totalViews !== null) {
+          $viewerCount
+            .attr('title', formatTotalViews(totalViews))
+        }
+      } else {
+        if (totalViews !== null) {
+          $viewerCount
+            .text(formatTotalViews(totalViews))
+            .removeAttr('title')
+        } else {
+          $viewerCount.remove()
+          return
+        }
       }
-
-      var viewerCount = this.model.get('viewer_count')
-      var viewerString = r.P_('%(num)s viewer', '%(num)s viewers', viewerCount)
-
-      $viewerCount
-        .text(viewerString.format({num: viewerCount}))
 
       if (!this.$viewerCount) {
         this.$viewerCount = $viewerCount
-        this.$el.find('.state').after($viewerCount)
-      }
-
-      return this
-    },
-
-    renderTotalViews: function() {
-      var $totalViews = this.$totalViews || $('<p class="total-views">')
-      var totalViews = this.model.get('total_views')
-
-      if (totalViews === null) {
-        $totalViews.remove()
-        return
-      }
-
-      if (totalViews < 999) {
-        var formattedTotalViews = totalViews
-      } else if (totalViews <= 999999) {
-        var formattedTotalViews = (totalViews / 1000).toFixed(1) + 'k'
-      } else {
-        var formattedTotalViews = (totalViews / 1000000).toFixed(2) + 'm'
-      }
-
-      var totalViewsString = r.P_('%(num)s view', '%(num)s views', totalViews)
-      $totalViews
-        .text(totalViewsString.format({num: formattedTotalViews}))
-
-      if (!this.$totalViews) {
-        this.$totalViews = $totalViews
-        this.$el.append($totalViews)
+        this.$el.append($viewerCount)
       }
 
       return this


### PR DESCRIPTION
This displays live total view counts in the status bar. A configurable
minimum date is used to ensure that only threads that we have full data
for have a view count shown; this prevents inaccurate or incomplete
counts from confusing users. The view count is updated once per minute
over websocket via the activity job. The view count will be visible
forever in the status bar of closed threads, and will continue to grow
if people view the thread later on.

Got some feedback from Derek and this is what the UI looks like:

Live, with view counts available:

![pasted image at 2017_10_13 09_54 am](https://user-images.githubusercontent.com/338853/31565616-47718912-b01c-11e7-89e8-907774739c18.png)

(live without view counts just doesn't get the tooltip)

Closed thread, with view counts available:

![screenshot from 2017-10-13 13-42-48](https://user-images.githubusercontent.com/338853/31565651-6c81a69c-b01c-11e7-8d8e-2544d68f5900.png)

(without view counts just shows "NO FURTHER UPDATES" with no more text)

(Note: this relies on the async view counts query stuff from r2, if that doesn't pan out I'll change the queries to use the sync style)