### PR TITLE
Add UI for hiding discussion thread links

### DIFF
--- a/reddit_liveupdate/__init__.py
+++ b/reddit_liveupdate/__init__.py
@@ -75,6 +75,8 @@ class LiveUpdate(Plugin):
             N_("there are too many pending invites outstanding"),
         "LIVEUPDATE_ALREADY_CONTRIBUTOR":
             N_("that user is already a contributor"),
+        "LIVEUPDATE_LINK_IS_NOT_DISCUSSION":
+            N_("the specified link is not a discussion about this live thread"),
     }
 
     config = {
@@ -211,6 +213,7 @@ class LiveUpdate(Plugin):
         )
 
         from r2.config.templates import api
+        from r2.lib.jsontemplates import ListingJsonTemplate
         from reddit_liveupdate import pages
         api('liveupdateeventapp', pages.LiveUpdateEventAppJsonTemplate)
         api('liveupdatefocusapp', pages.LiveUpdateEventAppJsonTemplate)
@@ -220,6 +223,7 @@ class LiveUpdate(Plugin):
         api('liveupdate', pages.LiveUpdateJsonTemplate)
         api('liveupdatecontributortableitem',
             pages.ContributorTableItemJsonTemplate)
+        api('liveupdatediscussionslisting', ListingJsonTemplate)
 
         controller_hooks.register_all()
 

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -508,6 +508,12 @@ class LiveUpdateController(RedditController):
         See also: [/api/live/*thread*/hide_discussion](#POST_api_live_{thread}_hide_discussion).
 
         """
+        url = pages.make_event_url(c.liveupdate_event._id)
+        if link.url != url:
+            c.errors.add(errors.LIVEUPDATE_LINK_IS_NOT_DISCUSSION)
+            form.set_error(errors.LIVEUPDATE_LINK_IS_NOT_DISCUSSION, None)
+            return
+
         c.liveupdate_event.unhide_discussion(link)
 
     def GET_edit(self):

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -482,6 +482,12 @@ class LiveUpdateController(RedditController):
         See also: [/api/live/*thread*/unhide_discussion](#POST_api_live_{thread}_unhide_discussion).
 
         """
+        # this prevents a potential information leak where you use the
+        # following link.url check to determine if links in a private subreddit
+        # point at a given live thread.
+        if link.subreddit_slow.type in Subreddit.private_types:
+            self.abort403()
+
         url = pages.make_event_url(c.liveupdate_event._id)
         if link.url != url:
             c.errors.add(errors.LIVEUPDATE_LINK_IS_NOT_DISCUSSION)
@@ -508,6 +514,12 @@ class LiveUpdateController(RedditController):
         See also: [/api/live/*thread*/hide_discussion](#POST_api_live_{thread}_hide_discussion).
 
         """
+        # this prevents a potential information leak where you use the
+        # following link.url check to determine if links in a private subreddit
+        # point at a given live thread.
+        if link.subreddit_slow.type in Subreddit.private_types:
+            self.abort403()
+
         url = pages.make_event_url(c.liveupdate_event._id)
         if link.url != url:
             c.errors.add(errors.LIVEUPDATE_LINK_IS_NOT_DISCUSSION)

--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -39,6 +39,7 @@ from r2.lib.validator import (
     VCount,
     VExistingUname,
     VLimit,
+    VLink,
     VMarkdownLength,
     VModhash,
     VRatelimit,
@@ -61,12 +62,12 @@ from r2.models import (
 )
 from r2.models.admintools import send_system_message
 from r2.lib.errors import errors
-from r2.lib.utils import url_links_builder
 from r2.lib.pages import AdminPage, PaneStack, Wrapped, RedditError, Reddit
 from r2.lib import amqp, geoip
 
 from reddit_liveupdate import pages, queries
 from reddit_liveupdate.contrib import iso3166
+from reddit_liveupdate.discussions import get_discussions
 from reddit_liveupdate.media_embeds import get_live_media_embed
 from reddit_liveupdate.models import (
     InviteNotFoundError,
@@ -453,17 +454,61 @@ class LiveUpdateController(RedditController):
     )
     def GET_discussions(self, num, after, reverse, count):
         """Get a list of reddit submissions linking to this thread."""
-        builder = url_links_builder(
-            url="/live/" + c.liveupdate_event._id,
-            num=num,
-            after=after,
-            reverse=reverse,
-            count=count,
-        )
+
+        show_hidden = c.liveupdate_permissions.allow("discussions")
+        builder = get_discussions(
+            c.liveupdate_event, limit=50, show_hidden=show_hidden)
         listing = LinkListing(builder).listing()
+        listing.render_class = pages.LiveUpdateDiscussionsListing
+        listing.submit_url = pages.make_submit_url(c.liveupdate_event)
         return pages.LiveUpdateEventPage(
             content=listing,
         ).render()
+
+    @require_oauth2_scope("livemanage")
+    @validatedForm(
+        VLiveUpdateContributorWithPermission("discussions"),
+        VModhash(),
+        link=VLink("link"),
+    )
+    @api_doc(
+        section=api_section.live,
+    )
+    def POST_hide_discussion(self, form, jquery, link):
+        """Hide a linked comment thread from the discussions sidebar and listing.
+
+        Requires the `discussions` permission for this thread.
+
+        See also: [/api/live/*thread*/unhide_discussion](#POST_api_live_{thread}_unhide_discussion).
+
+        """
+        url = pages.make_event_url(c.liveupdate_event._id)
+        if link.url != url:
+            c.errors.add(errors.LIVEUPDATE_LINK_IS_NOT_DISCUSSION)
+            form.set_error(errors.LIVEUPDATE_LINK_IS_NOT_DISCUSSION, None)
+            return
+
+        c.liveupdate_event.hide_discussion(link)
+        _broadcast(type="hide_discussion", payload={"link_id": link._id36})
+
+    @require_oauth2_scope("livemanage")
+    @validatedForm(
+        VLiveUpdateContributorWithPermission("discussions"),
+        VModhash(),
+        link=VLink("link"),
+    )
+    @api_doc(
+        section=api_section.live,
+    )
+    def POST_unhide_discussion(self, form, jquery, link):
+        """Unhide a linked comment thread from the discussions sidebar and listing..
+
+        Requires the `discussions` permission for this thread.
+
+        See also: [/api/live/*thread*/hide_discussion](#POST_api_live_{thread}_hide_discussion).
+
+        """
+        c.liveupdate_event.unhide_discussion(link)
 
     def GET_edit(self):
         if not (c.liveupdate_permissions.allow("settings") or

--- a/reddit_liveupdate/discussions.py
+++ b/reddit_liveupdate/discussions.py
@@ -3,7 +3,7 @@ import itertools
 from pylons import app_globals as g
 
 from r2.lib.memoize import memoize
-from r2.models import Link, NotFound, IDBuilder
+from r2.models import Link, NotFound, IDBuilder, Subreddit
 
 
 MAX_LINK_IDS_TO_CACHE = 50
@@ -31,6 +31,12 @@ def get_discussions(event, limit, show_hidden=False):
     hidden_links = event.hidden_discussions
     def _keep_discussion_link(link):
         if link._spam or link._deleted:
+            return False
+
+        # just don't allow any private subreddits so we don't get into a
+        # situation where an abusive link is posted in a private subreddit and
+        # contributors can't do anything about it because they can't see it.
+        if link.subreddit_slow.type in Subreddit.private_types:
             return False
 
         if not getattr(link, "allow_liveupdate", True):

--- a/reddit_liveupdate/discussions.py
+++ b/reddit_liveupdate/discussions.py
@@ -39,6 +39,9 @@ def get_discussions(event, limit, show_hidden=False):
         if link.subreddit_slow.type in Subreddit.private_types:
             return False
 
+        if not link.subreddit_slow.discoverable:
+            return False
+
         if not getattr(link, "allow_liveupdate", True):
             return False
 

--- a/reddit_liveupdate/discussions.py
+++ b/reddit_liveupdate/discussions.py
@@ -1,0 +1,54 @@
+import itertools
+
+from pylons import app_globals as g
+
+from r2.lib.memoize import memoize
+from r2.models import Link, NotFound, IDBuilder
+
+
+MAX_LINK_IDS_TO_CACHE = 50
+
+
+@memoize("live_update_discussion_fullnames", time=60)
+def _get_related_link_ids(event_id):
+    # imported here to avoid circular import
+    from reddit_liveupdate.pages import make_event_url
+
+    url = make_event_url(event_id)
+
+    try:
+        links = Link._by_url(url, sr=None)
+    except NotFound:
+        links = []
+
+    links = itertools.islice(links, MAX_LINK_IDS_TO_CACHE)
+    return [link._fullname for link in links]
+
+
+def get_discussions(event, limit, show_hidden=False):
+    """Return a builder providing Links that point at the given live thread."""
+
+    hidden_links = event.hidden_discussions
+    def _keep_discussion_link(link):
+        if link._spam or link._deleted:
+            return False
+
+        if not getattr(link, "allow_liveupdate", True):
+            return False
+
+        if link._score < g.liveupdate_min_score_for_discussions:
+            return False
+
+        link.is_hidden_discussion = link._id in hidden_links
+        if not show_hidden and link.is_hidden_discussion:
+            return False
+
+        return True
+
+    link_fullnames = _get_related_link_ids(event._id)
+    link_fullnames = link_fullnames[:limit]
+    return IDBuilder(
+        query=link_fullnames,
+        skip=True,
+        keep_fn=_keep_discussion_link,
+    )

--- a/reddit_liveupdate/permissions.py
+++ b/reddit_liveupdate/permissions.py
@@ -25,6 +25,11 @@ class ContributorPermissionSet(PermissionSet):
             "description": N_("strike and delete others' updates"),
         },
 
+        "discussions": {
+            "title": N_("hide discussions"),
+            "description": N_("unlink posts discussing this thread"),
+        },
+
         "close": {
             "title": N_("close live thread"),
             "description": N_("permanently close the live thread"),

--- a/reddit_liveupdate/public/static/js/liveupdate/init.js
+++ b/reddit_liveupdate/public/static/js/liveupdate/init.js
@@ -99,6 +99,17 @@
           model.set('embeds', data.media_embeds)
           this.embedViewer.restart()
         },
+        'message:hide_discussion': function(data) {
+          // until the discussions panel is properly live, this is just going
+          // to remove hidden links so they don't bother existing viewers of
+          // the live thread.
+          $('#discussion-' + data.link_id).remove()
+          if ($('#discussions div').length === 0) {
+            $('<p>')
+              .text(r._('no discussions yet.'))
+              .appendTo('#discussions')
+          }
+        },
         'message:complete': function() {
           this.event.set('state', 'complete')
           $options.remove()

--- a/reddit_liveupdate/templates/liveupdatediscussionslisting.html
+++ b/reddit_liveupdate/templates/liveupdatediscussionslisting.html
@@ -3,6 +3,8 @@
   from r2.lib.filters import safemarkdown
 %>
 
+<%namespace file="utils.html" import="_mdf" />
+
 <h1>${c.liveupdate_event.title}</h1>
 
 <style>
@@ -30,7 +32,7 @@
 </style>
 
 % if not thing.things:
-${unsafe(safemarkdown(_("no discussions yet. [start one]({url})").format(url=thing.submit_url), wrap=False))}
+${_mdf("no discussions yet. [start one](%(url)s)", wrap=False, url=thing.submit_url)}
 % else:
 <p>${_("Check out discussion about this live thread in the posts below.")}</p>
 

--- a/reddit_liveupdate/templates/liveupdatediscussionslisting.html
+++ b/reddit_liveupdate/templates/liveupdatediscussionslisting.html
@@ -1,0 +1,91 @@
+<%!
+  from r2.lib.strings import Score
+  from r2.lib.filters import safemarkdown
+%>
+
+<h1>${c.liveupdate_event.title}</h1>
+
+<style>
+  p {
+    font-size: 13px;
+  }
+
+  #discussions {
+    margin-top: 1em;
+    font-size: 13px;
+  }
+
+  #discussions th {
+    font-size: 15px;
+  }
+
+  #discussions th,
+  #discussions td {
+    padding: .5em 2em 0 0;
+  }
+
+  #discussions .pretty-button {
+    margin-bottom: 0;
+  }
+</style>
+
+% if not thing.things:
+${unsafe(safemarkdown(_("no discussions yet. [start one]({url})").format(url=thing.submit_url), wrap=False))}
+% else:
+<p>${_("Check out discussion about this live thread in the posts below.")}</p>
+
+<table id="discussions">
+% for link in thing.things:
+<tr data-link="${link._id36}" class="${'hidden' if link.is_hidden_discussion else ''}">
+  <th scope="row"><a href="${link.make_permalink(link.subreddit)}">${link.title}</a></th>
+  <td><a href="/r/${link.subreddit.name}">/r/${link.subreddit.name}</a></td>
+  <td>${Score.somethings(link.num_comments, "comment")}</td>
+</tr>
+% endfor
+</table>
+
+% if c.liveupdate_permissions.allow("discussions"):
+<script>
+$('#discussions tr').each(function(i, row) {
+  var $row = $(row);
+  var isHidden = $(row).hasClass('hidden');
+
+  $('<td>')
+    .append(
+        $('<button class="pretty-button positive" data-action="unhide_discussion">')
+          .text('${_("show")}')
+          .toggleClass('pressed', !isHidden)
+    )
+    .append(
+        $('<button class="pretty-button negative" data-action="hide_discussion">')
+          .text('${_("hide")}')
+          .toggleClass('pressed', isHidden)
+    )
+    .prependTo($row);
+});
+
+$('#discussions button').on('click', function(ev) {
+  var $button = $(ev.target);
+  var action = $button.data('action');
+  var $row = $button.closest('tr');
+  var linkId = $row.data('link');
+
+  $button.siblings('button')
+    .prop('disabled', false)
+    .removeClass('pressed');
+
+  $button
+    .prop('disabled', true)
+    .addClass('pressed');
+
+  r.ajax({
+    type: 'POST',
+    url: '/api/live/' + r.config.liveupdate_event + '/' + action,
+    data: {
+      'link': linkId,
+    },
+  });
+})
+</script>
+% endif
+% endif

--- a/reddit_liveupdate/templates/liveupdatediscussionslisting.html
+++ b/reddit_liveupdate/templates/liveupdatediscussionslisting.html
@@ -1,6 +1,6 @@
 <%!
   from r2.lib.strings import Score
-  from r2.lib.filters import safemarkdown
+  from r2.lib.filters import safemarkdown, scriptsafe_dumps
 %>
 
 <%namespace file="utils.html" import="_mdf" />
@@ -55,12 +55,12 @@ $('#discussions tr').each(function(i, row) {
   $('<td>')
     .append(
         $('<button class="pretty-button positive" data-action="unhide_discussion">')
-          .text('${_("show")}')
+          .text(${scriptsafe_dumps(_("show"))})
           .toggleClass('pressed', !isHidden)
     )
     .append(
         $('<button class="pretty-button negative" data-action="hide_discussion">')
-          .text('${_("hide")}')
+          .text(${scriptsafe_dumps(_("hide"))})
           .toggleClass('pressed', isHidden)
     )
     .prependTo($row);

--- a/reddit_liveupdate/templates/liveupdateotherdiscussions.html
+++ b/reddit_liveupdate/templates/liveupdateotherdiscussions.html
@@ -1,11 +1,14 @@
-<%! from r2.lib.filters import safemarkdown %>
+<%!
+  from r2.lib.strings import Score
+  from r2.lib.filters import safemarkdown
+%>
 
 % if thing.links:
 % for link in thing.links:
-<div>
+<div id="discussion-${link._id36}">
   <p><a href="${link.make_permalink(link.subreddit)}">${link.title}</a></p>
   <ul>
-    <li>${link.comments_label}</li>
+    <li>${Score.somethings(link.num_comments, "comment")}</li>
     <li><a href="/r/${link.subreddit.name}">/r/${link.subreddit.name}</a></li>
   </ul>
 </div>

--- a/reddit_liveupdate/templates/liveupdateotherdiscussions.html
+++ b/reddit_liveupdate/templates/liveupdateotherdiscussions.html
@@ -3,6 +3,8 @@
   from r2.lib.filters import safemarkdown
 %>
 
+<%namespace file="utils.html" import="_mdf" />
+
 % if thing.links:
 % for link in thing.links:
 <div id="discussion-${link._id36}">
@@ -18,5 +20,5 @@
 <p class="morelinks"><a href="/live/${c.liveupdate_event._id}/discussions">${_("see more")}</a></p>
 % endif
 % else:
-${unsafe(safemarkdown(_("no discussions yet. [start one]({url})").format(url=thing.submit_url), wrap=False))}
+${_mdf("no discussions yet. [start one](%(url)s)", wrap=False, url=thing.submit_url)}
 % endif


### PR DESCRIPTION
Since discussion threads show up in the sidebar when submitting links to
arbitrary subreddits, they're a vector for abuse. This adds data models,
UI, and reworked/centralized builder logic to allow discussion links to
be hidden from live threads. A new contributor permission is included.

Discussions are still not live-updated, so the websocket integration
here is minimal: we just remove the link from the sidebar if it exists
so that people who have already loaded the page don't have to keep
seeing weird stuff.

The main page UI looks identical, but you'll see that the offending link is hidden:

![screenshot from 2017-10-14 17-00-00](https://user-images.githubusercontent.com/338853/31580334-3fa902e2-b101-11e7-8d4f-d90c8618f507.png)

For non-contributors and contributors without the `discussions` permission, the discussions listing page has gotten a bit of a rework and a proper tab at the top but is otherwise pretty normal:

![screenshot from 2017-10-14 17-00-23](https://user-images.githubusercontent.com/338853/31580338-55e4b0e2-b101-11e7-959c-179ecae468cd.png)

But if you've got powers, you get to see the hidden stuff and get buttons to change the hide state:

![screenshot from 2017-10-14 17-00-17](https://user-images.githubusercontent.com/338853/31580341-5f3cf4ce-b101-11e7-87ed-402ec1c226f7.png)

This'll fix #14 (vintage!)