### PR TITLE
Fix validators and ByID controller for fullname change

### DIFF
--- a/reddit_liveupdate/validators.py
+++ b/reddit_liveupdate/validators.py
@@ -20,33 +20,17 @@ from reddit_liveupdate.permissions import ContributorPermissionSet
 
 
 class VLiveUpdateEvent(Validator):
-    splitter = re.compile('[ ,]+')
-
-    def __init__(self, param, multiple=False, **kw):
-        self.multiple = multiple
-        Validator.__init__(self, param, kw)
-
     def param_docs(self):
-        if self.multiple:
-            return {
-                self.param: ("A comma-separated list of ids"),
-            }
-        else:
-            return {
-                self.param: ("A live update event id"),
-            }
+        return {
+            self.param: "a live thread fullname",
+        }
 
     def run(self, id):
-
         if not id:
             return None
 
         try:
-            if self.multiple:
-                items = self.splitter.split(id)
-            else:
-                items = id
-            return models.LiveUpdateEvent._byID(items)
+            return models.LiveUpdateEvent._by_fullname(id)
         except tdb_cassandra.NotFound:
             return None
 


### PR DESCRIPTION
VLiveUpdateEvent was only used on the main event listings and /by_id/. I
split it up so that the special casing logic could live only with
/by_id/.

The fullnames get passed onto `LiveUpdateEventBuilder.thing_lookup` which 
now expects fullnames.