### PR TITLE
Fix happening_now after the fullname change

### DIFF
--- a/reddit_liveupdate/validators.py
+++ b/reddit_liveupdate/validators.py
@@ -49,7 +49,10 @@ class VLiveUpdateEventUrl(VLiveUpdateEvent):
         if not event_id:
             return None
 
-        return VLiveUpdateEvent.run(self, event_id.group(1))
+        try:
+            return models.LiveUpdateEvent._byID(event_id.group(1))
+        except tdb_cassandra.NotFound:
+            return None
 
 
 class VLiveUpdateID(Validator):


### PR DESCRIPTION
Apologies, the fullname fix has broken yet another thing. I missed this because
I juggled too many branches and did insufficient testing.

Rather than sticking with IDs I standardized on storing fullnames so
that it works natively with the listing.