### PR TITLE
Remove GeoIP data from events.

### DIFF
--- a/reddit_liveupdate/tests/eventcollector_tests.py
+++ b/reddit_liveupdate/tests/eventcollector_tests.py
@@ -43,7 +43,6 @@ class TestEventCollector(RedditTestCase):
             'user_id': self.context.user._id,
             'user_name': self.context.user.name,
 
-            'geoip_country': self.context.location,
             'oauth2_client_id': self.context.oauth2_client._id,
             'oauth2_client_app_type': self.context.oauth2_client.app_type,
             'oauth2_client_name': self.context.oauth2_client.name,


### PR DESCRIPTION
This functionality predated the data pipeline's ability to add GeoIP
data to events as they are received, so we don't need this anymore.
This was causing a lot of extra load to the rickety old GeoIP service
so we definitely don't need to be doing duplicate work.

👓 @spladug 