### PR TITLE
Io 3799 deprecate secure media object phase 2

### DIFF
--- a/reddit_liveupdate/media_embeds.py
+++ b/reddit_liveupdate/media_embeds.py
@@ -82,7 +82,7 @@ def _scrape_mobile_media_objects(urls):
 def _scrape_mobile_media_object(url):
     scraper = _LiveEmbedlyScraper(url)
     try:
-        _, _, _, result = scraper.scrape()
+        _, _, result = scraper.scrape()
         result['oembed']['original_url'] = url
         return result['oembed']
     except:
@@ -104,7 +104,7 @@ def _scrape_media_object(url, autoplay=False, maxwidth=_EMBED_WIDTH):
     scraper = LiveScraper.for_url(url, autoplay=autoplay, maxwidth=maxwidth)
 
     try:
-        thumbnail, preview, _, secure_media_object = scraper.scrape()
+        thumbnail, preview, secure_media_object = scraper.scrape()
     except (HTTPError, URLError):
         g.log.info("Unable to scrape suspected scrapable URL: %r", url)
         return None
@@ -178,7 +178,7 @@ class _EmbedlyCardFallbackScraper(Scraper):
         self.scraper = scraper
 
     def scrape(self):
-        thumb, preview, _, secure_media_object = self.scraper.scrape()
+        thumb, preview, secure_media_object = self.scraper.scrape()
 
         # ok, the upstream scraper failed so let's make an embedly card
         if not secure_media_object:

--- a/reddit_liveupdate/media_embeds.py
+++ b/reddit_liveupdate/media_embeds.py
@@ -165,11 +165,11 @@ class _LiveEmbedlyScraper(_OEmbedScraper):
 
     def scrape(self):
         if not self.oembed:
-            return None, None, None, None
+            return None, None, None
 
         # Deprecate use of media_object with None, prefer secure
         secure_media_object = self.make_media_object(self.oembed)
-        return None, None, None, secure_media_object
+        return None, None, secure_media_object
 
 
 class _EmbedlyCardFallbackScraper(Scraper):
@@ -192,7 +192,7 @@ class _EmbedlyCardFallbackScraper(Scraper):
             }
 
         # Deprecate use of media_object with None, prefer secure
-        return thumb, preview, None, secure_media_object
+        return thumb, preview, secure_media_object
 
     @classmethod
     def media_embed(cls, media_object):
@@ -245,14 +245,13 @@ class _TwitterScraper(Scraper):
     def scrape(self):
         oembed = self._fetch_from_twitter()
         if not oembed:
-            return None, None, None, None
+            return None, None, None
 
         media_object = self._make_media_object(oembed)
 
         return (
             None,  # no thumbnails for twitter
             None,
-            None, # Deprecate use of media_object with None, prefer secure
             media_object,  # Twitter's response is ssl ready by default
         )
 

--- a/reddit_liveupdate/scraper.py
+++ b/reddit_liveupdate/scraper.py
@@ -33,7 +33,6 @@ class _LiveUpdateScraper(Scraper):
         return (
             None,
             None,
-            None, # Deprecate use of media_object with None, prefer secure
             self._make_media_object(),
         )
 


### PR DESCRIPTION
Previous 3 steps of deployment are completed:
1. stopped reading from media_object
2. stopped writing media_object
3. stopped returning media_object

this is step number 4 to change the behavior of the scrapers to only return 3 objects instead of 4. with the part of media_object being removed from return value and namedTuples.