### PR TITLE
Cache `/api/live/happening_now`.

### DIFF
--- a/reddit_liveupdate/controllers.py
+++ b/reddit_liveupdate/controllers.py
@@ -1145,6 +1145,8 @@ class LiveUpdateEventsController(RedditController):
         if not is_api():
             self.abort404()
 
+        response.headers["Cache-Control"] = "max-age=300"
+
         featured_event = get_featured_event()
         if not featured_event:
             response.status_code = 204


### PR DESCRIPTION
This is requested 800-1000/s at peak and rarely changes.

I'm open to suggestions on time! Just guessed at 300s but we might want to lower it.

👓 @spladug 