### PR TITLE
Deprecate use of obsolete link.allow_liveupdate

### DIFF
--- a/reddit_liveupdate/discussions.py
+++ b/reddit_liveupdate/discussions.py
@@ -42,9 +42,6 @@ def get_discussions(event, limit, show_hidden=False):
         if not link.subreddit_slow.discoverable:
             return False
 
-        if not getattr(link, "allow_liveupdate", True):
-            return False
-
         if link._score < g.liveupdate_min_score_for_discussions:
             return False
 


### PR DESCRIPTION
There's only 19 rows in postgres for the `allow_live_update` key and it hasn't been written to in a year. Think it's safe to deprecate.